### PR TITLE
Allow for rule values to contain Handlebars

### DIFF
--- a/src/render/Helpers/Date.ts
+++ b/src/render/Helpers/Date.ts
@@ -26,7 +26,7 @@ const isUnit = (value: DateUnit): boolean => ['years', 'months', 'weeks', 'days'
 /**
  * Perform date math on a given date by adding some unit to the date.
  *
- * i.e. {{ #addDate "1974-01-23" 1 "month" }}
+ * i.e. {{addDate "1974-01-23" 1 "months" }}
  */
 export const addDate = function(date: Date | string, amount: number, unit: DateUnit): Date {
     if (!isUnit(unit)) return baseDate(date)
@@ -37,7 +37,7 @@ export const addDate = function(date: Date | string, amount: number, unit: DateU
 /**
  * Perform date math on a given date by subtracting some unit to the date.
  *
- * i.e. {{ #subDate "1974-01-23" 1 "month" }}
+ * i.e. {{subDate "1974-01-23" 1 "months" }}
  */
 export const subtractDate = function(date: Date | string, amount: number, unit: DateUnit): Date {
     if (!isUnit(unit)) return baseDate(date)

--- a/src/rules/Rule.ts
+++ b/src/rules/Rule.ts
@@ -1,12 +1,16 @@
-export type Operator = '=' | '!=' | '<' |'<=' | '>' | '>=' | '=' | 'is set' | 'is not set' | 'or' | 'and' | 'xor'
+export type Operator = '=' | '!=' | '<' |'<=' | '>' | '>=' | '=' | 'is set' | 'is not set' | 'or' | 'and' | 'xor' | 'empty' | 'contains' | 'any' | 'none'
 export type RuleType = 'wrapper' | 'string' | 'number' | 'boolean' | 'date' | 'array'
 export type RuleGroup = 'user' | 'event'
+
+export type AnyJson = boolean | number | string | null | JsonArray | JsonMap
+export interface JsonMap { [key: string]: AnyJson }
+export type JsonArray = Array<AnyJson>
 
 export default interface Rule {
     type: RuleType
     group: RuleGroup
     path: string
     operator: Operator
-    value?: unknown
+    value?: AnyJson
     children?: Rule[]
 }

--- a/src/rules/RuleEngine.ts
+++ b/src/rules/RuleEngine.ts
@@ -1,7 +1,7 @@
 import jsonpath from 'jsonpath'
 import { TemplateEvent } from '../users/UserEvent'
 import { TemplateUser } from '../users/User'
-import Rule, { Operator, RuleGroup, RuleType } from './Rule'
+import Rule, { AnyJson, JsonArray, Operator, RuleGroup, RuleType } from './Rule'
 import { isAfter, isBefore, isEqual } from 'date-fns'
 import { Compile } from '../render'
 
@@ -38,9 +38,30 @@ class RuleEvalException extends Error {
 const queryValue = <T>(input: RuleCheckInput, rule: Rule, cast: (item: any) => T): T | undefined => {
     const inputValue = input[rule.group]
     if (!inputValue) return undefined
-    const pathValue = jsonpath.query(input[rule.group], rule.path)
+    const pathValue = jsonpath.query(input[rule.group], rule.path)?.[0]
     if (!pathValue) return undefined
     return cast(pathValue)
+}
+
+const checkArrayOperators = <T>(input: T, operator: Operator, value: T[]): boolean => {
+    if (operator === 'any') {
+        return value.includes(input)
+    }
+    if (operator === 'none') {
+        return !value.includes(input)
+    }
+    return false
+}
+
+const compile = <Y>(rule: Rule, cast: (item: AnyJson) => Y): Y => {
+    const value = rule.value
+    if (!value) {
+        throw new RuleEvalException(rule, 'value required for operator')
+    }
+    const compiledValue = typeof value === 'string' && value.includes('{')
+        ? Compile(value)
+        : value
+    return cast(compiledValue)
 }
 
 const WrapperRule: RuleCheck = {
@@ -69,16 +90,34 @@ const StringRule: RuleCheck = {
         const value = queryValue(input, rule, item => String(item))
         if (!value) return false
 
+        if (rule.operator === 'is set') {
+            return value != null && value !== ''
+        }
+
+        if (rule.operator === 'is not set') {
+            return value == null
+        }
+
+        if (rule.operator === 'empty') {
+            return value.length <= 0
+        }
+
+        const ruleValue = compile(rule, item => String(item))
+
         if (rule.operator === '=') {
-            return value === rule.value
+            return value === ruleValue
         }
 
         if (rule.operator === '!=') {
-            return value !== rule.value
+            return value !== ruleValue
         }
 
-        if (rule.operator === 'is set') {
-            return value != null && value !== ''
+        if (rule.operator === 'contains') {
+            return value.includes(ruleValue)
+        }
+
+        if (Array.isArray(rule.value)) {
+            return checkArrayOperators(value, rule.operator, rule.value)
         }
 
         throw new RuleEvalException(rule, 'unknown operator: ' + rule.operator)
@@ -98,10 +137,7 @@ const NumberRule: RuleCheck = {
             return value == null
         }
 
-        if (!rule.value) {
-            throw new RuleEvalException(rule, 'value required for operator')
-        }
-        const ruleValue = Number(rule.value)
+        const ruleValue = compile(rule, item => Number(item))
 
         if (rule.operator === '=') {
             return value === ruleValue
@@ -127,13 +163,22 @@ const NumberRule: RuleCheck = {
             return value >= ruleValue
         }
 
+        if (Array.isArray(rule.value)) {
+            return checkArrayOperators(value, rule.operator, rule.value)
+        }
+
         throw new RuleEvalException(rule, 'unknown operator: ' + rule.operator)
     },
 }
 
 const BooleanRule: RuleCheck = {
     check(input: RuleCheckInput, rule: Rule) {
-        const value = queryValue(input, rule, item => Boolean(item))
+        const value = queryValue(input, rule, item => {
+            if (typeof item === 'boolean') return item
+            if (typeof item === 'string') return item === 'true'
+            if (typeof item === 'number') return item === 1
+            return false
+        })
         return value === rule.value
     },
 }
@@ -151,13 +196,12 @@ const DateRule: RuleCheck = {
             return value == null
         }
 
-        if (!rule.value) {
-            throw new RuleEvalException(rule, 'value required for operator')
-        }
-
-        // Use Handlebars to manipulate date before interpreting
-        const compiledValue = Compile(String(rule.value))
-        const ruleValue = new Date(compiledValue)
+        const ruleValue = compile(rule, item => {
+            if (typeof item === 'string' || typeof item === 'number') {
+                return new Date(item)
+            }
+            throw new RuleEvalException(rule, 'invalid value for date comparison')
+        })
 
         if (rule.operator === '=') {
             return isEqual(value, ruleValue)
@@ -187,10 +231,54 @@ const DateRule: RuleCheck = {
     },
 }
 
+const ArrayRule: RuleCheck = {
+    check(input: RuleCheckInput, rule: Rule) {
+        const value = queryValue(input, rule, item => {
+            return Array.isArray(item) ? item : [item]
+        }) as JsonArray
+        if (!value) return false
+
+        if (rule.operator === 'is set') {
+            return value != null
+        }
+
+        if (rule.operator === 'is not set') {
+            return value == null
+        }
+
+        if (rule.operator === 'empty') {
+            return value.length <= 0
+        }
+
+        if (!rule.value) {
+            throw new RuleEvalException(rule, 'value required for operator')
+        }
+
+        if (rule.operator === '=') {
+            return value === rule.value
+        }
+
+        if (rule.operator === '!=') {
+            return value !== rule.value
+        }
+
+        if (Array.isArray(rule.value)) {
+            return checkArrayOperators(value, rule.operator, rule.value)
+        }
+
+        if (rule.operator === 'contains') {
+            return value.includes(rule.value)
+        }
+
+        throw new RuleEvalException(rule, 'unknown operator: ' + rule.operator)
+    },
+}
+
 ruleRegistry.register('number', NumberRule)
 ruleRegistry.register('string', StringRule)
 ruleRegistry.register('boolean', BooleanRule)
 ruleRegistry.register('date', DateRule)
+ruleRegistry.register('array', ArrayRule)
 ruleRegistry.register('wrapper', WrapperRule)
 
 export const check = (value: RuleCheckInput, rules: Rule[]) => {
@@ -203,7 +291,7 @@ interface RuleMake {
     group?: RuleGroup
     path?: string
     operator?: Operator
-    value?: unknown
+    value?: AnyJson
     children?: Rule[]
 }
 

--- a/src/rules/__test__/RuleEngine.spec.ts
+++ b/src/rules/__test__/RuleEngine.spec.ts
@@ -1,3 +1,4 @@
+import { subDays } from 'date-fns'
 import { check, make } from '../RuleEngine'
 
 describe('RuleEngine', () => {
@@ -45,6 +46,51 @@ describe('RuleEngine', () => {
                 make({ type: 'string', path: '$.project', operator: 'is set' }),
             ])
             expect(shouldPass).toBeFalsy()
+        })
+    })
+
+    describe('date', () => {
+        test('is set', () => {
+            const value = {
+                user: {
+                    id: 'abcd',
+                    email: 'test@test.com',
+                    createdAt: Date.now(),
+                },
+            }
+            const shouldPass = check(value, [
+                make({ type: 'date', path: '$.createdAt', operator: 'is set' }),
+            ])
+            expect(shouldPass).toBeTruthy()
+        })
+
+        test('greater than or equals', () => {
+            const now = Date.now()
+            const value = {
+                user: {
+                    id: 'abcd',
+                    email: 'test@test.com',
+                    createdAt: now,
+                },
+            }
+            const shouldPass = check(value, [
+                make({ type: 'date', path: '$.createdAt', operator: '>=', value: now }),
+            ])
+            expect(shouldPass).toBeTruthy()
+        })
+
+        test('compilation', () => {
+            const value = {
+                user: {
+                    id: 'abcd',
+                    email: 'test@test.com',
+                    createdAt: subDays(new Date(), 1).getTime(),
+                },
+            }
+            const shouldPass = check(value, [
+                make({ type: 'date', path: '$.createdAt', operator: '>', value: '{{subDate "now" 1 "months" }}' }),
+            ])
+            expect(shouldPass).toBeTruthy()
         })
     })
 


### PR DESCRIPTION
- Date, string and number type fields can now contain Handlebars logic to manipulate values
- Particularly helpful for things like dates where you may want to reference now. For example if you wanted to compare to thirty days ago you could do `{{subDate "now" 30 "days" }}`

Resolves #38 