### PR TITLE
Adds retry in case of deadlocks during lock extension

### DIFF
--- a/apps/platform/src/config/scheduler.ts
+++ b/apps/platform/src/config/scheduler.ts
@@ -117,7 +117,8 @@ class SchedulerLock {
                         .where((subQb) => {
                             subQb.where('owner', owner)
                                 .orWhere('expiration', '<=', new Date())
-                        }),
+                        })
+                        .orderBy('id'),
                 {
                     owner,
                     expiration,


### PR DESCRIPTION
Competing instances were locking up rows when extending job lock. This retries (which is the suggested approach for at least MySQL) as well as safely fails if one isn't acquired