### PR TITLE
Sending Template Proofs

### DIFF
--- a/apps/platform/src/render/TemplateController.ts
+++ b/apps/platform/src/render/TemplateController.ts
@@ -4,7 +4,7 @@ import { JSONSchemaType, validate } from '../core/validate'
 import { searchParamsSchema } from '../core/searchParams'
 import { extractQueryParams } from '../utilities'
 import Template, { TemplateParams, TemplateUpdateParams } from './Template'
-import { createTemplate, getTemplate, pagedTemplates, updateTemplate } from './TemplateService'
+import { createTemplate, getTemplate, pagedTemplates, sendProof, updateTemplate } from './TemplateService'
 import { Variables } from '.'
 import { User } from '../users/User'
 import { UserEvent } from '../users/UserEvent'
@@ -210,6 +210,32 @@ router.post('/:templateId/preview', async ctx => {
         event: UserEvent.fromJson(payload.event || {}),
         context: payload.context || {},
     })
+})
+
+interface TemplateProofParams {
+    variables: any
+    recipient: string
+}
+
+const templateProofParams: JSONSchemaType<TemplateProofParams> = {
+    $id: 'templateProof',
+    type: 'object',
+    required: ['recipient'],
+    properties: {
+        variables: {
+            type: 'object',
+            nullable: true,
+            additionalProperties: true,
+        },
+        recipient: { type: 'string' },
+    },
+    additionalProperties: false,
+}
+router.post('/:templateId/proof', async ctx => {
+    const { variables, recipient } = validate(templateProofParams, ctx.request.body)
+    const template = ctx.state.template!.map()
+
+    ctx.body = await sendProof(template, variables, recipient)
 })
 
 export default router

--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios'
 import { env } from './config/env'
-import { Admin, Campaign, CampaignCreateParams, CampaignLaunchParams, CampaignUpdateParams, CampaignUser, Image, Journey, JourneyStepMap, JourneyStepStats, List, ListCreateParams, ListUpdateParams, Project, ProjectAdminCreateParams, ProjectApiKey, ProjectApiKeyParams, Provider, ProviderCreateParams, ProviderMeta, ProviderUpdateParams, SearchParams, SearchResult, Subscription, SubscriptionParams, Tag, Template, TemplateCreateParams, TemplatePreviewParams, TemplateUpdateParams, User, UserEvent, UserSubscription } from './types'
+import { Admin, Campaign, CampaignCreateParams, CampaignLaunchParams, CampaignUpdateParams, CampaignUser, Image, Journey, JourneyStepMap, JourneyStepStats, List, ListCreateParams, ListUpdateParams, Project, ProjectAdminCreateParams, ProjectApiKey, ProjectApiKeyParams, Provider, ProviderCreateParams, ProviderMeta, ProviderUpdateParams, SearchParams, SearchResult, Subscription, SubscriptionParams, Tag, Template, TemplateCreateParams, TemplatePreviewParams, TemplateProofParams, TemplateUpdateParams, User, UserEvent, UserSubscription } from './types'
 
 function appendValue(params: URLSearchParams, name: string, value: unknown) {
     if (typeof value === 'undefined' || value === null || typeof value === 'function') return
@@ -170,6 +170,7 @@ const api = {
     templates: {
         ...createProjectEntityPath<Template, TemplateCreateParams, TemplateUpdateParams>('templates'),
         preview: async (projectId: number | string, templateId: number | string, params: TemplatePreviewParams) => await client.post(`${projectUrl(projectId)}/templates/${templateId}/preview`, params),
+        proof: async (projectId: number | string, templateId: number | string, params: TemplateProofParams) => await client.post(`${projectUrl(projectId)}/templates/${templateId}/proof`, params),
     },
 
     users: {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -346,6 +346,11 @@ export interface TemplatePreviewParams {
     ontext: Record<string, any>
 }
 
+export interface TemplateProofParams {
+    variables: TemplatePreviewParams
+    recipient: string
+}
+
 export enum SubscriptionState {
     unsubscribed = 0,
     subscribed = 1,


### PR DESCRIPTION
Allow for sending proofs of email and sms templates to a given recipient. Super helpful for seeing how something will show up on the end device (especially emails)