### PR TITLE
Allow for link wrapping deep links

### DIFF
--- a/apps/platform/src/config/env.ts
+++ b/apps/platform/src/config/env.ts
@@ -12,6 +12,10 @@ export interface Env {
     port: number
     secret: string
     auth: AuthConfig
+    tracking: {
+        linkWrap: boolean,
+        deeplinkMirrorUrl: string | undefined,
+    }
 }
 
 export interface DriverConfig {
@@ -91,5 +95,9 @@ export default (type?: EnvType): Env => {
                 tokenLife: defaultTokenLife,
             }),
         }),
+        tracking: {
+            linkWrap: (process.env.TRACKING_LINK_WRAP ?? 'true') === 'true',
+            deeplinkMirrorUrl: process.env.TRACKING_DEEPLINK_MIRROR_URL,
+        },
     }
 }

--- a/apps/platform/src/render/LinkController.ts
+++ b/apps/platform/src/render/LinkController.ts
@@ -16,4 +16,15 @@ router.get('/o', async ctx => {
     ctx.status = 204
 })
 
+router.get('/.well-known/:file', async ctx => {
+    const url = App.main.env.tracking.deeplinkMirrorUrl
+    const file = ctx.params.file
+    if (!url) {
+        ctx.status = 404
+        return
+    }
+    const response = await fetch(`${url}/.well-known/${file}`)
+    ctx.body = await response.json()
+})
+
 export default router

--- a/apps/platform/src/render/index.ts
+++ b/apps/platform/src/render/index.ts
@@ -7,6 +7,7 @@ import * as ArrayHelpers from './Helpers/Array'
 import { User } from '../users/User'
 import { unsubscribeEmailLink } from '../subscriptions/SubscriptionService'
 import { clickWrapHtml, openWrapHtml, preheaderWrapHtml } from './LinkService'
+import App from '../app'
 
 export interface RenderContext {
     template_id: number
@@ -49,7 +50,13 @@ interface WrapParams {
 }
 export const Wrap = ({ html, preheader, variables: { user, context } }: WrapParams) => {
     const trackingParams = { userId: user.id, campaignId: context.campaign_id }
-    html = clickWrapHtml(html, trackingParams)
+
+    // Check if link wrapping is enabled first
+    if (App.main.env.tracking.linkWrap) {
+        html = clickWrapHtml(html, trackingParams)
+    }
+
+    // Open wrap & preheader wrap
     html = openWrapHtml(html, trackingParams)
     if (preheader) html = preheaderWrapHtml(html, preheader)
     return html

--- a/apps/ui/docker/nginx/conf.d/default.conf
+++ b/apps/ui/docker/nginx/conf.d/default.conf
@@ -7,11 +7,7 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    location /api {
-        proxy_pass http://api:3001;
-    }
-
-    location /uploads {
+    location ~ ^/(api|uploads|.well-known)/ {
         proxy_pass http://api:3001;
     }
 

--- a/docs/docs/advanced/_category_.json
+++ b/docs/docs/advanced/_category_.json
@@ -1,0 +1,6 @@
+{
+    "label": "Advanced",
+    "position": 5,
+    "collapsible": true
+  }
+  

--- a/docs/docs/advanced/config.md
+++ b/docs/docs/advanced/config.md
@@ -1,3 +1,4 @@
+# Configuration
 Find below a list of all environment variables that can be set at launch to configure different portions of the application:
 
 

--- a/docs/docs/advanced/config.md
+++ b/docs/docs/advanced/config.md
@@ -1,0 +1,58 @@
+Find below a list of all environment variables that can be set at launch to configure different portions of the application:
+
+
+### General
+| key | type | required |
+|--|--|--|
+| BASE_URL | string | true |
+| PORT | number | true |
+| APP_SECRET | string | true |
+
+### Database
+| key | type | required |
+|--|--|--|
+| DB_HOST | string | true |
+| DB_USERNAME | string | true |
+| DB_PORT | number | true |
+| DB_DATABASE | string | true |
+
+### Queue
+| key | type | required |
+|--|--|--|
+| QUEUE_DRIVER | 'sqs' or 'memory' | true |
+| AWS_SQS_QUEUE_URL | string | If driver is SQS |
+| AWS_REGION | string | If driver is SQS |
+| AWS_ACCESS_KEY_ID | string | If driver is SQS |
+| AWS_SECRET_ACCESS_KEY | string | If driver is SQS |
+
+
+### Storage
+| key | type | required |
+|--|--|--|
+| STORAGE_BASE_URL | string | true |
+| STORAGE_DRIVER | 's3' or 'local' | true |
+| AWS_S3_BUCKET | string | If driver is S3 |
+| AWS_REGION | string | If driver is S3 |
+| AWS_ACCESS_KEY_ID | string | If driver is S3 |
+| AWS_SECRET_ACCESS_KEY | string | If driver is S3 |
+
+### Auth
+| key | type | required |
+|--|--|--|
+| AUTH_DRIVER | 'openid' or 'saml' | true |
+| AUTH_SAML_CALLBACK_URL | string | If driver is SAML |
+| AUTH_SAML_ENTRY_POINT_URL | string | If driver is SAML |
+| AUTH_SAML_ISSUER | string | If driver is SAML |
+| AUTH_SAML_CERT | string | If driver is SAML |
+| AUTH_SAML_IS_AUTHN_SIGNED | boolean | If driver is SAML |
+| AUTH_OPENID_ISSUER_URL | string | If driver is OpenID |
+| AUTH_OPENID_CLIENT_ID | string | If driver is OpenID |
+| AUTH_OPENID_CLIENT_SECRET | string | If driver is OpenID |
+| AUTH_OPENID_REDIRECT_URI | string | If driver is OpenID |
+| AUTH_OPENID_DOMAIN_WHITELIST | string | If driver is OpenID |
+
+### Tracking
+| key | type | required |
+|--|--|--|
+| TRACKING_LINK_WRAP | boolean | false
+| TRACKING_DEEPLINK_MIRROR_URL | string | false

--- a/docs/docs/advanced/deeplinking.md
+++ b/docs/docs/advanced/deeplinking.md
@@ -1,0 +1,17 @@
+# Deeplinking
+
+If you are wanting to use universal links and link wrapping together, you will need to configure Parcelvoy appropriately.
+
+Both Apple and Google require a domain with HTTPS as well as a file be present on that domain ([apple-app-site-association file (iOS)](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) and [assetlinks.json file (Android)](https://developer.android.com/training/app-links/verify-site-associations)). Link wrapping a universal link wraps the URL in the Parcelvoy URL which could cause universal links to stop opening in app. To solve this, Parcelvoy supports proxing those files from a remote source so that they are always present when your app requests them.
+
+To setup link wrapping all you have to do is provide as an environment variables the URL at which you already have the two files hosted under `.well-known`.
+
+```
+TRACKING_DEEPLINK_MIRROR_URL=https://your-domain-here.com
+```
+
+If you wish instead to turn link wrapping off entirely, you can do so as well.
+
+```
+TRACKING_LINK_WRAP=false
+```


### PR DESCRIPTION
Deep links and universal links are rejected by apps if they don't have some files present in the `.well-known` folder. This allows a user to set a URL to proxy those files from