### PR TITLE
Add Redis queue option

### DIFF
--- a/apps/platform/package-lock.json
+++ b/apps/platform/package-lock.json
@@ -22,6 +22,7 @@
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
+        "bullmq": "^3.10.2",
         "busboy": "^1.6.0",
         "csv-parse": "^5.3.3",
         "date-fns": "^2.29.2",
@@ -2250,6 +2251,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2748,6 +2754,78 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@node-saml/node-saml": {
       "version": "4.0.3",
@@ -4159,6 +4237,66 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/bullmq": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-3.10.2.tgz",
+      "integrity": "sha512-GyunDkMdGJRUIo3n+jjQH9Uxz0Z+DLLbuz/7uxcQ+tFss1zB/zmn33D3l+rHaO8I52vz8C7hhEa2lCJ0GIhGgA==",
+      "dependencies": {
+        "cron-parser": "^4.6.0",
+        "glob": "^8.0.3",
+        "ioredis": "^5.3.0",
+        "lodash": "^4.17.21",
+        "msgpackr": "^1.6.2",
+        "semver": "^7.3.7",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/bullmq/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -4346,6 +4484,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -6552,6 +6698,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.1.tgz",
+      "integrity": "sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -8024,10 +8193,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8239,6 +8418,35 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
+      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.1"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+      }
+    },
     "node_modules/mysql2": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
@@ -8371,6 +8579,17 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -9280,6 +9499,25 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -9811,6 +10049,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/static-eval": {
       "version": "2.0.2",

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -16,6 +16,7 @@
     "ajv": "^8.11.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
+    "bullmq": "^3.10.2",
     "busboy": "^1.6.0",
     "csv-parse": "^5.3.3",
     "date-fns": "^2.29.2",

--- a/apps/platform/src/client/SegmentController.ts
+++ b/apps/platform/src/client/SegmentController.ts
@@ -16,15 +16,18 @@ const segmentEventsRequest: JSONSchemaType<SegmentPostEventsRequest> = {
     type: 'array',
     items: {
         type: 'object',
-        required: ['event', 'type'],
+        required: ['type'],
         properties: {
-            event: { type: 'string' },
             type: { type: 'string' },
+            event: {
+                type: 'string',
+                nullable: true,
+            },
             anonymousId: {
                 type: 'string',
                 nullable: true,
             },
-            externalId: {
+            userId: {
                 type: 'string',
                 nullable: true,
             },
@@ -50,7 +53,7 @@ const segmentEventsRequest: JSONSchemaType<SegmentPostEventsRequest> = {
                 required: ['anonymousId'],
             },
             {
-                required: ['externalId'],
+                required: ['userId'],
             },
         ],
     },

--- a/apps/platform/src/config/env.ts
+++ b/apps/platform/src/config/env.ts
@@ -56,6 +56,10 @@ export default (type?: EnvType): Env => {
                     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
                 },
             }),
+            redis: () => ({
+                host: process.env.REDIS_HOST!,
+                port: parseInt(process.env.REDIS_PORT!),
+            }),
         }),
         storage: driver<StorageConfig>(process.env.STORAGE_DRIVER ?? 'local', {
             s3: () => ({

--- a/apps/platform/src/queue/Queue.ts
+++ b/apps/platform/src/queue/Queue.ts
@@ -3,9 +3,10 @@ import { logger, LoggerConfig } from '../config/logger'
 import Job, { EncodedJob } from './Job'
 import MemoryQueueProvider, { MemoryConfig } from './MemoryQueueProvider'
 import QueueProvider, { QueueProviderName } from './QueueProvider'
+import RedisQueueProvider, { RedisConfig } from './RedisQueueProvider'
 import SQSQueueProvider, { SQSConfig } from './SQSQueueProvider'
 
-export type QueueConfig = SQSConfig | MemoryConfig | LoggerConfig
+export type QueueConfig = SQSConfig | RedisConfig | MemoryConfig | LoggerConfig
 
 export interface QueueTypeConfig extends DriverConfig {
     driver: QueueProviderName
@@ -18,6 +19,8 @@ export default class Queue {
     constructor(config?: QueueConfig) {
         if (config?.driver === 'sqs') {
             this.provider = new SQSQueueProvider(config, this)
+        } else if (config?.driver === 'redis') {
+            this.provider = new RedisQueueProvider(config, this)
         } else if (config?.driver === 'memory') {
             this.provider = new MemoryQueueProvider(this)
         } else {

--- a/apps/platform/src/queue/QueueProvider.ts
+++ b/apps/platform/src/queue/QueueProvider.ts
@@ -1,11 +1,10 @@
 import Queue from './Queue'
 import Job from './Job'
 
-export type QueueProviderName = 'sqs' | 'memory' | 'logger'
+export type QueueProviderName = 'sqs' | 'redis' | 'memory' | 'logger'
 
 export default interface QueueProvider {
     queue: Queue
     enqueue(job: Job): Promise<void>
-    start(): void
     close(): void
 }

--- a/apps/platform/src/queue/RedisQueueProvider.ts
+++ b/apps/platform/src/queue/RedisQueueProvider.ts
@@ -1,0 +1,47 @@
+import { Queue as BullQueue, Worker } from 'bullmq'
+import { logger } from '../config/logger'
+import Job from './Job'
+import Queue, { QueueTypeConfig } from './Queue'
+import QueueProvider from './QueueProvider'
+
+export interface RedisConfig extends QueueTypeConfig {
+    driver: 'redis'
+    host: string
+    port: number
+}
+
+export default class RedisQueueProvider implements QueueProvider {
+
+    config: RedisConfig
+    queue: Queue
+    bull: BullQueue
+    worker: Worker
+
+    constructor(config: RedisConfig, queue: Queue) {
+        this.queue = queue
+        this.config = config
+        this.bull = new BullQueue('parcelvoy', { connection: config })
+        this.worker = new Worker('parcelvoy', async job => {
+            await this.queue.dequeue(job.data)
+        }, { connection: config })
+        this.worker.on('failed', (job, error) => {
+            logger.error({ error }, 'sqs:error:processing')
+        })
+    }
+
+    async enqueue(job: Job): Promise<void> {
+        try {
+            await this.bull.add(job.name, job, {
+                removeOnComplete: 50,
+                removeOnFail: 50,
+                delay: job.options.delay,
+            })
+        } catch (error) {
+            logger.error(error, 'sqs:error:enqueue')
+        }
+    }
+
+    close(): void {
+        this.worker.close()
+    }
+}

--- a/apps/platform/src/queue/SQSQueueProvider.ts
+++ b/apps/platform/src/queue/SQSQueueProvider.ts
@@ -61,10 +61,6 @@ export default class SQSQueueProvider implements QueueProvider {
         }
     }
 
-    start(): void {
-        this.app.start()
-    }
-
     close(): void {
         this.app.stop()
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       test: "/usr/bin/mysql parcelvoy --user=root --password=$$MYSQL_ROOT_PASSWORD --execute 'SELECT 1;'"
       interval: 1s
       retries: 120
+  redis:
+    image: redis
+    expose:
+      - "6379"
+    restart: always
+    volumes:
+      - redis_data:/data
   api:
     image: 'ghcr.io/parcelvoy/api:latest'
     restart: always
@@ -23,6 +30,8 @@ services:
       - mysql:mysql
     depends_on:
       mysql:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     environment:
       NODE_ENV: ${NODE_ENV}
@@ -39,6 +48,8 @@ services:
       STORAGE_BASE_URL: ${STORAGE_BASE_URL}
       AWS_S3_BUCKET: ${AWS_S3_BUCKET}
       QUEUE_DRIVER: ${QUEUE_DRIVER}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}
       AWS_SQS_QUEUE_URL: ${AWS_SQS_QUEUE_URL}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -66,6 +77,8 @@ services:
       - 80:3000
 volumes:
   mysql_data:
+    driver: local
+  redis_data:
     driver: local
   uploads:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       mysql:
         condition: service_healthy
       redis:
-        condition: service_healthy
+        condition: service_started
     environment:
       NODE_ENV: ${NODE_ENV}
       BASE_URL: ${BASE_URL}
@@ -70,7 +70,8 @@ services:
   ui:
     image: 'ghcr.io/parcelvoy/ui:latest'
     depends_on:
-      - api
+      api:
+        condition: service_started
     environment:
       API_BASE_URL: ${API_BASE_URL}
     ports:

--- a/docs/docs/providers/segment.md
+++ b/docs/docs/providers/segment.md
@@ -28,7 +28,7 @@ There is currently no Destination in Segment for Parcelvoy, however Parcelvoy do
 11. Under mappings, enter the following information:
     - **URL**: Enter your domain along with the path `/api/client/segment` (i.e. `https://test.com/api/client/segment`)
     - **Method**: POST
-    - **Headers**: Set the key as `Authorization` and the value as the key you created in Parcelvoy
+    - **Headers**: Set the key as `Authorization` and the value to `Bearer API_KEY` where `API_KEY` is the key you created in Parcelvoy
     - **Data**: Leave as is
     - **Enable Batching**: Set to true
 12. Save the destination and enable to start sending events into Parcelvoy!.


### PR DESCRIPTION
Adds Redis as an option for queues using BullMQ under the hood. The existing memory queue was pretty limiting as a "get started only with docker compose" option and adding Redis into that reduced memory usage overall but also allows for persistence across restarts