### PR TITLE
Fixes locale parsing edge case

### DIFF
--- a/apps/platform/src/utilities/index.ts
+++ b/apps/platform/src/utilities/index.ts
@@ -85,8 +85,9 @@ export const batch = <T>(arr: T[], size: number) => {
 }
 
 export const parseLocale = (locale: string): string | undefined => {
-    const parts = locale.split('-')
-    return parts.length === 1 ? locale[0] : locale
+    return locale.slice(-1) === '-'
+        ? locale.slice(0, -1)
+        : locale
 }
 
 export const partialMatchLocale = (locale1?: string, locale2?: string) => {


### PR DESCRIPTION
Segment 99% of the time always has a `-` in their locales, but sometimes one comes in without one strangely