### PR TITLE
Adds from name and auto text email

### DIFF
--- a/apps/platform/src/providers/email/Email.ts
+++ b/apps/platform/src/providers/email/Email.ts
@@ -1,6 +1,8 @@
+export type NamedEmail = { name: string, address: string }
+
 export interface Email {
     to: string
-    from: string
+    from: string | NamedEmail
     cc?: string
     bcc?: string
     reply_to?: string

--- a/apps/platform/src/render/TemplateController.ts
+++ b/apps/platform/src/render/TemplateController.ts
@@ -24,8 +24,18 @@ const templateDataEmailParams = {
     type: 'object',
     properties: {
         from: {
-            type: 'string',
+            type: 'object',
             nullable: true,
+            properties: {
+                name: {
+                    type: 'string',
+                    nullable: true,
+                },
+                address: {
+                    type: 'string',
+                    nullable: true,
+                },
+            },
         },
         cc: {
             type: 'string',

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -300,7 +300,7 @@ export type CampaignLaunchParams = Pick<Campaign, 'send_at' | 'send_in_user_time
 export type CampaignUser = User & { state: CampaignSendState, send_at: string }
 
 export interface EmailTemplateData {
-    from: string
+    from: { name: string, address: string }
     cc?: string
     bcc?: string
     reply_to?: string

--- a/apps/ui/src/ui/Preview.tsx
+++ b/apps/ui/src/ui/Preview.tsx
@@ -12,7 +12,7 @@ export default function Preview({ template }: PreviewProps) {
 
     const EmailFrame = () => <div className="email-frame">
         <div className="email-frame-header">
-            <span className="email-from">{data.from}</span>
+            <span className="email-from">{data.from.name} &lt;{data.from.address}&gt;</span>
             <span className="email-subject">{data.subject}</span>
         </div>
         <Iframe content={data.html ?? ''} />

--- a/apps/ui/src/views/campaign/CampaignForm.tsx
+++ b/apps/ui/src/views/campaign/CampaignForm.tsx
@@ -27,6 +27,7 @@ interface ListSelectionProps extends SelectionProps<CampaignCreateParams> {
     project: Project
     title: string
     value?: List[]
+    required: boolean
 }
 
 const ListSelection = ({
@@ -35,6 +36,7 @@ const ListSelection = ({
     name,
     title,
     value,
+    required,
 }: ListSelectionProps) => {
     const [isOpen, setIsOpen] = useState(false)
     const [lists, setLists] = useState<List[]>(value ?? [])
@@ -57,7 +59,7 @@ const ListSelection = ({
         control,
         name,
         rules: {
-            required: true,
+            required,
         },
     })
 
@@ -243,6 +245,7 @@ export function CampaignForm({ campaign, disableListSelection, onSave }: Campaig
                                     name="list_ids"
                                     value={campaign?.lists}
                                     control={form.control}
+                                    required={true}
                                 />
                                 <ListSelection
                                     project={project}
@@ -250,6 +253,7 @@ export function CampaignForm({ campaign, disableListSelection, onSave }: Campaig
                                     name="exclusion_list_ids"
                                     value={campaign?.exclusion_lists}
                                     control={form.control}
+                                    required={false}
                                 />
                             </>
                         )

--- a/apps/ui/src/views/campaign/EmailEditor.tsx
+++ b/apps/ui/src/views/campaign/EmailEditor.tsx
@@ -17,6 +17,7 @@ import ImageGalleryModal from './ImageGalleryModal'
 import Modal from '../../ui/Modal'
 import { ImageIcon } from '../../ui/icons'
 import EditLocalesModal from './EditLocalesModal'
+import { toast } from 'react-hot-toast'
 
 const HtmlEditor = ({ template, setTemplate }: { template: Template, setTemplate: (template: Template) => void }) => {
 
@@ -26,6 +27,7 @@ const HtmlEditor = ({ template, setTemplate }: { template: Template, setTemplate
     const [data, setData] = useState(template.data)
     const [selectedIndex, setSelectedIndex] = useState(0)
     const [showImages, setShowImages] = useState(false)
+    const [isSaving, setIsSaving] = useState(false)
 
     function handleMount(editor: Editor.IStandaloneCodeEditor) {
         setMonaco(editor)
@@ -63,9 +65,17 @@ const HtmlEditor = ({ template, setTemplate }: { template: Template, setTemplate
         }
     }
 
-    function handleSave() {
-        template.data = data
-        setTemplate(template)
+    async function handleSave() {
+        try {
+            setIsSaving(true)
+            template.data = data
+            await setTemplate(template)
+            toast.success('Saved!')
+        } catch (error) {
+            toast.error('Unable to save template.')
+        } finally {
+            setIsSaving(false)
+        }
     }
 
     return (
@@ -120,7 +130,7 @@ const HtmlEditor = ({ template, setTemplate }: { template: Template, setTemplate
                     <span className="publish-label">Last updated at</span>
                     <span className="publish-date">{formatDate(preferences, template.updated_at)}</span>
                 </div>
-                <Button onClick={() => handleSave()}>Save</Button>
+                <Button onClick={async () => await handleSave()} isLoading={isSaving}>Save</Button>
             </div>
 
             <ImageGalleryModal

--- a/apps/ui/src/views/campaign/TemplateDetail.tsx
+++ b/apps/ui/src/views/campaign/TemplateDetail.tsx
@@ -13,7 +13,8 @@ import TextInput from '../../ui/form/TextInput'
 import api from '../../api'
 
 const EmailTable = ({ data }: { data: EmailTemplateData }) => <InfoTable rows={{
-    'From Email': data.from,
+    'From Email': data.from?.address,
+    'From Name': data.from?.name,
     'Reply To': data.reply_to,
     CC: data.cc,
     BCC: data.bcc,
@@ -33,7 +34,8 @@ const EmailForm = ({ form }: { form: UseFormReturn<TemplateUpdateParams, any> })
         name="data.preheader"
         label="Preheader"
         textarea />
-    <TextInput.Field form={form} name="data.from" label="From Email" required />
+    <TextInput.Field form={form} name="data.from.address" label="From Email" required />
+    <TextInput.Field form={form} name="data.from.name" label="From Name" required />
     <TextInput.Field form={form} name="data.reply_to" label="Reply To" />
     <TextInput.Field form={form} name="data.cc" label="CC" />
     <TextInput.Field form={form} name="data.bcc" label="BCC" />


### PR DESCRIPTION
- Adds toast to templates
- Allows for a human readable name to be set for emails (to show up as a name in inboxes)
- Automatically generates a text copy of an email from HTML if none is provided