### PR TITLE
Allow For NULL External ID

### DIFF
--- a/apps/platform/db/migrations/20230419032608_users_allow_null_external_id.js
+++ b/apps/platform/db/migrations/20230419032608_users_allow_null_external_id.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+    await knex.schema.table('users', function(table) {
+        table.string('external_id', 255).nullable().alter()
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('users', function(table) {
+        table.string('external_id', 255).notNullable().alter()
+    })
+}

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -2,6 +2,7 @@ import { ClientAliasParams, ClientIdentity } from '../client/Client'
 import { SearchParams } from '../core/searchParams'
 import { subscribeAll } from '../subscriptions/SubscriptionService'
 import { Device, DeviceParams, User, UserParams } from '../users/User'
+import { uuid } from '../utilities'
 
 export const getUser = async (id: number, projectId?: number): Promise<User | undefined> => {
     return await User.find(id, qb => {
@@ -75,7 +76,7 @@ export const aliasUser = async (projectId: number, {
 export const createUser = async (projectId: number, { external_id, anonymous_id, data, ...fields }: UserParams) => {
     const user = await User.insertAndFetch({
         project_id: projectId,
-        anonymous_id,
+        anonymous_id: anonymous_id ?? uuid(),
         external_id,
         data: data ?? {},
         ...fields,


### PR DESCRIPTION
Fixes an assumption that an external ID will always be present which is not true. A user can have just an anonymous ID value that can later be aliased (this is especially true of our mobile SDK)