### PR TITLE
Fixes SES inbound notifications

### DIFF
--- a/apps/platform/src/providers/email/SESEmailProvider.ts
+++ b/apps/platform/src/providers/email/SESEmailProvider.ts
@@ -111,7 +111,7 @@ export default class SESEmailProvider extends EmailProvider {
         const getHeader = (
             headers: Array<{ name: string, value: string }>,
             key: string,
-        ) => (headers ?? []).find((item) => item.name === key)?.value
+        ) => (headers ?? []).find((item) => item.name.toLowerCase() === key.toLowerCase())?.value
 
         const json = JSON.parse(message) as Record<string, any>
         const { notificationType, mail: { destination, headers } } = json


### PR DESCRIPTION
SES oddly capitalizes certain fields for no apparent reason, this lowercases their header keys so we can appropriately match against them. This was preventing bounces, etc from being reported correctly