### PR TITLE
adds bundle analyzer, shards visual editor

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -34,6 +34,7 @@
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "reactflow": "11.5.6",
+    "source-map-explorer": "2.5.3",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },

--- a/apps/ui/src/views/campaign/editor/EmailEditor.tsx
+++ b/apps/ui/src/views/campaign/editor/EmailEditor.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useContext, useState } from 'react'
+import { SetStateAction, Suspense, lazy, useContext, useState } from 'react'
 import { CampaignContext, LocaleContext, LocaleSelection, ProjectContext } from '../../../contexts'
 import './EmailEditor.css'
 import Button from '../../../ui/Button'
@@ -7,10 +7,11 @@ import { Campaign, Template } from '../../../types'
 import { useNavigate } from 'react-router-dom'
 import { localeState } from '../CampaignDetail'
 import Modal from '../../../ui/Modal'
-import VisualEditor from './VisualEditor'
 import HtmlEditor from './HtmlEditor'
 import LocaleSelector from '../LocaleSelector'
 import { toast } from 'react-hot-toast'
+
+const VisualEditor = lazy(async () => await import('./VisualEditor'))
 
 export default function EmailEditor() {
     const navigate = useNavigate()
@@ -66,10 +67,14 @@ export default function EmailEditor() {
                         {templates.filter(template => template.locale === locale.currentLocale?.key)
                             .map(template => (
                                 template.data.editor === 'visual'
-                                    ? <VisualEditor
-                                        template={template}
-                                        key={template.id}
-                                        setTemplate={setTemplate} />
+                                    ? (
+                                        <Suspense key={template.id} fallback={null}>
+                                            <VisualEditor
+                                                template={template}
+                                                setTemplate={setTemplate}
+                                            />
+                                        </Suspense>
+                                    )
                                     : <HtmlEditor
                                         template={template}
                                         key={template.id}

--- a/apps/ui/src/views/campaign/editor/VisualEditor.tsx
+++ b/apps/ui/src/views/campaign/editor/VisualEditor.tsx
@@ -20,7 +20,7 @@ interface GrapesReactProps {
     setAssetState: (props: GrapesAssetManagerProps) => void
 }
 
-export function GrapesReact({ id, mjml, onChange, setAssetState }: GrapesReactProps) {
+function GrapesReact({ id, mjml, onChange, setAssetState }: GrapesReactProps) {
     const [editor, setEditor] = useState<Editor | undefined>(undefined)
     useEffect(() => {
         if (!editor) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
-        "@textea/json-viewer": "^2.17.0",
+        "@textea/json-viewer": "2.16.2",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.11.41",
         "@types/react": "^18.0.14",
@@ -156,6 +156,8 @@
         "clsx": "^1.2.1",
         "date-fns": "^2.29.3",
         "date-fns-tz": "^1.3.7",
+        "grapesjs": "^0.21.1",
+        "grapesjs-mjml": "^1.0.4",
         "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
         "react-charts": "^3.0.0-beta.54",
@@ -166,6 +168,7 @@
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "reactflow": "11.5.6",
+        "source-map-explorer": "2.5.3",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
       },
@@ -178,6 +181,23 @@
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.31.11",
         "typescript": "^4.9.3"
+      }
+    },
+    "apps/ui/node_modules/@textea/json-viewer": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@textea/json-viewer/-/json-viewer-2.16.2.tgz",
+      "integrity": "sha512-ZPRNpcLJ+hOO6C8tzkQvltRSp7Ol73j8oJ1+w5mWVWn+JR1QqzZJJgBqnNZvs3S1h/jJAjwyeZUVlb0VtIJcvg==",
+      "dependencies": {
+        "@emotion/react": "^11.10.6",
+        "@emotion/styled": "^11.10.6",
+        "@mui/material": "^5.11.14",
+        "clsx": "^1.2.1",
+        "copy-to-clipboard": "^3.3.3",
+        "zustand": "^4.3.6"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
     "apps/ui/node_modules/@types/node": {
@@ -7648,23 +7668,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@textea/json-viewer": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@textea/json-viewer/-/json-viewer-2.17.0.tgz",
-      "integrity": "sha512-irVkq9R22V966rXrL/isuh6f+fvdUJlshOyVuuEoa+qGwYMYWHcVolUAgGnBM8aW9AJ+v3TVw44QDOK/H8xZlg==",
-      "dependencies": {
-        "@emotion/react": "^11.10.6",
-        "@emotion/styled": "^11.10.6",
-        "@mui/material": "^5.12.0",
-        "clsx": "^1.2.1",
-        "copy-to-clipboard": "^3.3.3",
-        "zustand": "^4.3.7"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -9881,6 +9884,23 @@
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
+    "node_modules/backbone": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==",
+      "dependencies": {
+        "underscore": ">=1.8.3"
+      }
+    },
+    "node_modules/backbone-undo": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/backbone-undo/-/backbone-undo-0.2.6.tgz",
+      "integrity": "sha512-AsfpNiljLXlk7TcffDUu3EAUq7CxWbyTNwARWrql5XTzN4vh6WzEEBZYaKK4kTTz+iW1tSzqUooaGRIwO83kWA==",
+      "dependencies": {
+        "backbone": ">=1.0.0",
+        "underscore": ">=1.4.4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -10181,6 +10201,17 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -10794,6 +10825,16 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.13",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
+      "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
+    },
+    "node_modules/codemirror-formatting": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/codemirror-formatting/-/codemirror-formatting-1.0.0.tgz",
+      "integrity": "sha512-br9yM6eJI3pJHekEnoyHaBEb1B7XxxDjju+vRyBe8QGLp5saTIXXkZ+eFCTqXSAtI8QEZDFVEX2/SOjH2sVWRQ=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -14996,6 +15037,32 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/grapesjs": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/grapesjs/-/grapesjs-0.21.1.tgz",
+      "integrity": "sha512-gbOQtnF+lEHJBD5LnZ1FR7oMk3YjLP9S8IeH2pC2wUEEkvXocWIQxyiJCo9CkSUexHNDEIFZg6xDYVcpy0yPWg==",
+      "dependencies": {
+        "backbone": "1.4.1",
+        "backbone-undo": "^0.2.5",
+        "codemirror": "^5.63.0",
+        "codemirror-formatting": "^1.0.0",
+        "promise-polyfill": "^8.1.3",
+        "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/grapesjs-mjml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapesjs-mjml/-/grapesjs-mjml-1.0.4.tgz",
+      "integrity": "sha512-Apo/o5R0y4J8rlHvITPyA/O5ws7O1x+R5Krr+GZUdi9E7Rk68Pc6uc19pm4R+ys/NKp1a2SlY8/6qugnt4xPFA==",
+      "dependencies": {
+        "mjml-browser": "^4.13.0"
+      }
+    },
+    "node_modules/grapesjs/node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -20342,6 +20409,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/mjml-browser": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/mjml-browser/-/mjml-browser-4.14.1.tgz",
+      "integrity": "sha512-kkY43kYTGfw0qL251GrG3hdQvKeeKAzxgM+zFd97Pay2nZX06W9V6rm03zCfnOQdwGM90xMOBF+x9SIhRPkiJQ=="
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -24201,6 +24273,11 @@
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -27316,6 +27393,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-explorer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.3.tgz",
+      "integrity": "sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==",
+      "dependencies": {
+        "btoa": "^1.2.1",
+        "chalk": "^4.1.0",
+        "convert-source-map": "^1.7.0",
+        "ejs": "^3.1.5",
+        "escape-html": "^1.0.3",
+        "glob": "^7.1.6",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "open": "^7.3.1",
+        "source-map": "^0.7.4",
+        "temp": "^0.9.4",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "sme": "bin/cli.js",
+        "source-map-explorer": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -28272,6 +28428,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -28279,6 +28447,58 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/temp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/temp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/temp/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/tempy": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "lerna run lint",
     "test": "lerna run test",
     "docker:build": "lerna run docker:build",
-    "docker:build:push": "lerna run docker:build:push"
+    "docker:build:push": "lerna run docker:build:push",
+    "analyze:ui:bundle": "lerna run build && npx source-map-explorer './apps/ui/build/static/js/*.js'"
   }
 }


### PR DESCRIPTION
- run `npm run analyze:ui:bundle` to see dependency sizes
- lazy load `VisualEditor` because dependencies are quite large