### PR TITLE
Campaign sending improvements

### DIFF
--- a/apps/platform/db/migrations/20230504131759_add_user_indexes.js
+++ b/apps/platform/db/migrations/20230504131759_add_user_indexes.js
@@ -1,0 +1,13 @@
+exports.up = async function(knex) {
+    await knex.schema.table('users', function(table) {
+        table.index('email')
+        table.index('phone')
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('users', function(table) {
+        table.dropIndex('email')
+        table.dropIndex('phone')
+    })
+}

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -330,6 +330,16 @@ export const recipientQuery = (campaign: Campaign) => {
 
         // Filter out existing sends (handle aborts & reschedules)
         .whereNull('campaign_sends.id')
+
+        // Based on campaign type, filter out based on missing user
+        // criteria
+        .where(qb => {
+            if (campaign.channel === 'email') {
+                qb.whereNotNull('users.email')
+            } else if (campaign.channel === 'text') {
+                qb.whereNotNull('users.phone')
+            }
+        })
 }
 
 export const abortCampaign = async (campaign: Campaign) => {

--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -69,6 +69,7 @@ describe('CampaignService', () => {
         return await User.insertAndFetch({
             project_id,
             external_id: uuid(),
+            email: `${uuid()}@test.com`,
             data: {},
         })
     }

--- a/apps/ui/src/views/campaign/CampaignOverview.tsx
+++ b/apps/ui/src/views/campaign/CampaignOverview.tsx
@@ -9,7 +9,7 @@ import Modal from '../../ui/Modal'
 import { PreferencesContext } from '../../ui/PreferencesContext'
 import { formatDate } from '../../utils'
 import { CampaignForm } from './CampaignForm'
-import { CampaignTag } from './Campaigns'
+import { CampaignTag, DeliveryRatio } from './Campaigns'
 import ChannelTag from './ChannelTag'
 
 export default function CampaignOverview() {
@@ -56,7 +56,7 @@ export default function CampaignOverview() {
                 in_timezone: campaign.send_in_user_timezone ? 'Yes' : 'No',
                 send_lists: DelimitedLists({ lists: campaign.lists }),
                 exclusion_lists: DelimitedLists({ lists: campaign.exclusion_lists }),
-                delivery: `${campaign.delivery?.sent ?? 0} / ${campaign.delivery?.total ?? 0}`,
+                delivery: DeliveryRatio({ delivery: campaign.delivery }),
             }} />
             <Modal
                 open={isEditOpen}

--- a/apps/ui/src/views/campaign/Campaigns.tsx
+++ b/apps/ui/src/views/campaign/Campaigns.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import api from '../../api'
-import { Campaign, CampaignState } from '../../types'
+import { Campaign, CampaignDelivery, CampaignState } from '../../types'
 import Button from '../../ui/Button'
 import { ArchiveIcon, DuplicateIcon, EditIcon, PlusIcon } from '../../ui/icons'
 import Menu, { MenuItem } from '../../ui/Menu'
@@ -26,6 +26,12 @@ export const CampaignTag = ({ state }: { state: CampaignState }) => {
     return <Tag variant={variant[state]}>
         {snakeToTitle(state)}
     </Tag>
+}
+
+export const DeliveryRatio = ({ delivery }: { delivery: CampaignDelivery }) => {
+    const sent = (delivery?.sent ?? 0).toLocaleString()
+    const total = (delivery?.total ?? 0).toLocaleString()
+    return `${sent} / ${total}`
 }
 
 export default function Campaigns() {
@@ -74,7 +80,7 @@ export default function Campaigns() {
                         },
                         {
                             key: 'delivery',
-                            cell: ({ item }) => `${item.delivery?.sent ?? 0} / ${item.delivery?.total ?? 0}`,
+                            cell: ({ item: { delivery } }) => DeliveryRatio({ delivery }),
                         },
                         {
                             key: 'send_at',


### PR DESCRIPTION
- Adds indexes to email and phone (completes PV-43)
- Fixes exclusion lists that weren't working (completes PV-42)
- Improves who campaigns are sent to (filtering out people without requisite values) (completes PV-41)
- Fixes initial list count not calculating properly because the math was wrong