### PR TITLE
Universal links require a 200 status for registered path

### DIFF
--- a/apps/platform/src/render/LinkController.ts
+++ b/apps/platform/src/render/LinkController.ts
@@ -5,9 +5,18 @@ import { encodedLinkToParts, trackLinkEvent } from './LinkService'
 const router = new Router<{app: App}>()
 
 router.get('/c', async ctx => {
+
+    // If no redirect, just show a default page
+    if (!ctx.query.redirect) {
+        ctx.body = `It looks like this link doesn't work properly!`
+        ctx.status = 200
+        return
+    }
+
     const parts = await encodedLinkToParts(ctx.URL)
     await trackLinkEvent(parts, 'clicked')
     ctx.redirect(parts.redirect)
+    ctx.status = 303
 })
 
 router.get('/o', async ctx => {

--- a/apps/platform/src/render/LinkController.ts
+++ b/apps/platform/src/render/LinkController.ts
@@ -8,7 +8,7 @@ router.get('/c', async ctx => {
 
     // If no redirect, just show a default page
     if (!ctx.query.redirect) {
-        ctx.body = `It looks like this link doesn't work properly!`
+        ctx.body = 'It looks like this link doesn\'t work properly!'
         ctx.status = 200
         return
     }


### PR DESCRIPTION
This PR moves base route to a 200 status instead of the original 302