### PR TITLE
Fixes push notification sending

### DIFF
--- a/apps/platform/src/users/User.ts
+++ b/apps/platform/src/users/User.ts
@@ -15,21 +15,16 @@ export interface UserAttribute {
     value: any
 }
 
-export class Device extends Model {
-    device_id!: string
+export interface Device {
+    device_id: string
     token?: string
-    notifications_enabled!: boolean
-    os!: string
-    model!: string
-    app_build!: string
-    app_version!: string
-
-    get isPushEnabled(): boolean {
-        return this.token != null && this.notifications_enabled
-    }
+    os: string
+    model: string
+    app_build: string
+    app_version: string
 }
 
-export type DeviceParams = Omit<Device, ModelParams | 'notifications_enabled' | 'isPushEnabled'> & ClientIdentity
+export type DeviceParams = Omit<Device, ModelParams> & ClientIdentity
 
 interface PushEnabledDevice extends Device {
     token: string
@@ -59,7 +54,7 @@ export class User extends Model {
     }
 
     get pushEnabledDevices(): PushEnabledDevice[] {
-        return this.devices?.filter(device => device.isPushEnabled) as PushEnabledDevice[]
+        return this.devices?.filter(device => device.token != null) as PushEnabledDevice[] ?? []
     }
 
     get fullName() {

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -94,16 +94,17 @@ export const saveDevice = async (projectId: number, { external_id, anonymous_id,
     if (!user) return
 
     if (!user.devices) user.devices = []
-    const device = user.devices?.find(
-        device => device.device_id === params.device_id,
-    )
+    const device = user.devices?.find(device => {
+        return device.device_id === params.device_id
+            || (device.token === params.token && device.token != null)
+    })
     if (device) {
         Object.assign(device, params)
     } else {
-        user.devices.push(Device.fromJson({
+        user.devices.push({
             ...params,
             device_id: params.device_id,
-        }))
+        })
     }
     await User.updateAndFetch(user.id, { devices: user.devices })
     return device
@@ -113,7 +114,7 @@ export const disableNotifications = async (userId: number, tokens: string[]): Pr
     const user = await User.find(userId)
     if (!user) return false
     const device = user.devices?.find(device => device.token && tokens.includes(device.token))
-    if (device) device.notifications_enabled = false
+    if (device) device.token = undefined
     await User.update(qb => qb.where('id', userId), {
         devices: user.devices,
     })

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -162,6 +162,16 @@ export interface User {
     timezone?: string
     locale?: string
     data: Record<string, any>
+    devices?: Device[]
+}
+
+export interface Device {
+    device_id: string
+    token?: string
+    os: string
+    model: string
+    app_build: string
+    app_version: string
 }
 
 export interface UserEvent {

--- a/apps/ui/src/views/users/UserDetailAttrs.tsx
+++ b/apps/ui/src/views/users/UserDetailAttrs.tsx
@@ -5,12 +5,12 @@ import JsonPreview from '../../ui/JsonPreview'
 
 export default function UserDetail() {
 
-    const [{ external_id, email, phone, timezone, locale, data }] = useContext(UserContext)
+    const [{ external_id, email, phone, timezone, locale, devices, data }] = useContext(UserContext)
 
     return <>
         <Heading size="h3" title="Details" />
         <section className="container">
-            <JsonPreview value={{ external_id, email, phone, timezone, locale, ...data }} />
+            <JsonPreview value={{ external_id, email, phone, timezone, locale, devices, ...data }} />
         </section>
     </>
 }


### PR DESCRIPTION
Currently we assume a device is a model object. The way it's stored though is just as JSON inside of the models table. This means whenever devices are pulled, they don't have the instance method needed to determine if they can be sent. This PR moves to assuming a device is just an object. It also improves handling for some edge cases and improves the UI 

Completes PV-54