### PR TITLE
Forces string conversion to better use indexes

### DIFF
--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -17,10 +17,10 @@ export const getUserFromClientId = async (projectId: number, identity: ClientIde
     return await User.first(
         qb => qb.where(sqb => {
             if (identity.external_id) {
-                sqb.where('external_id', identity.external_id)
+                sqb.where('external_id', `${identity.external_id}`)
             }
             if (identity.anonymous_id) {
-                sqb.orWhere('anonymous_id', identity.anonymous_id)
+                sqb.orWhere('anonymous_id', `${identity.anonymous_id}`)
             }
         }).where('project_id', projectId),
     )


### PR DESCRIPTION
MySQL has an issue where if a value is passed in a different type than a column the indexes dont appear to be fully used causing significantly worse performance