### PR TITLE
Add campaign types

### DIFF
--- a/apps/platform/db/migrations/20230516214727_add_campaign_type.js
+++ b/apps/platform/db/migrations/20230516214727_add_campaign_type.js
@@ -1,0 +1,12 @@
+exports.up = async function(knex) {
+    await knex.schema.table('campaigns', function(table) {
+        table.string('type', 255).after('id')
+    })
+    await knex.raw('UPDATE campaigns SET type = IF(list_ids IS NULL, "trigger", "blast")')
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('campaigns', function(table) {
+        table.dropColumn('type')
+    })
+}

--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -15,8 +15,11 @@ export interface CampaignDelivery {
 
 export type CampaignProgress = CampaignDelivery & { pending: number }
 
+type CampaignType = 'blast' | 'trigger'
+
 export default class Campaign extends Model {
     project_id!: number
+    type!: CampaignType
     name!: string
     list_ids?: number[]
     lists?: List[]
@@ -44,7 +47,7 @@ export type SentCampaign = Campaign & { send_at: Date }
 
 export type CampaignParams = Omit<Campaign, ModelParams | 'delivery' | 'screenshotUrl' | 'templates' | 'lists' | 'exclusion_lists' | 'subscription' | 'provider' | 'deleted_at'>
 export type CampaignCreateParams = Omit<CampaignParams, 'state'>
-export type CampaignUpdateParams = Omit<CampaignParams, 'channel'>
+export type CampaignUpdateParams = Omit<CampaignParams, 'channel' | 'type'>
 
 export type CampaignSendState = 'pending' | 'sent' | 'throttled' | 'failed' | 'bounced' | 'aborted'
 export class CampaignSend extends Model {

--- a/apps/platform/src/campaigns/CampaignController.ts
+++ b/apps/platform/src/campaigns/CampaignController.ts
@@ -25,8 +25,12 @@ router.get('/', async ctx => {
 export const campaignCreateParams: JSONSchemaType<CampaignCreateParams> = {
     $id: 'campaignCreate',
     type: 'object',
-    required: ['subscription_id', 'provider_id'],
+    required: ['type', 'subscription_id', 'provider_id'],
     properties: {
+        type: {
+            type: 'string',
+            enum: ['blast', 'trigger'],
+        },
         name: {
             type: 'string',
         },

--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -57,6 +57,7 @@ describe('CampaignService', () => {
 
         const campaign = await createCampaign(params.project_id, {
             name: uuid(),
+            type: 'blast',
             channel: 'email',
             ...params,
             ...extras,
@@ -137,6 +138,7 @@ describe('CampaignService', () => {
             const campaign = await createCampaign(params.project_id, {
                 ...params,
                 channel: 'email',
+                type: 'blast',
                 name,
             })
 
@@ -151,6 +153,7 @@ describe('CampaignService', () => {
             const name = uuid()
             const promise = createCampaign(params.project_id, {
                 channel: 'email',
+                type: 'blast',
                 subscription_id: 0,
                 provider_id: params.provider_id,
                 name,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -284,9 +284,12 @@ export interface CampaignDelivery {
     clicks: number
 }
 
+export type CampaignType = 'blast' | 'trigger'
+
 export interface Campaign {
     id: number
     project_id: number
+    type: CampaignType
     name: string
     channel: ChannelType
     state: CampaignState
@@ -310,7 +313,7 @@ export interface Campaign {
 export type CampaignSendState = 'pending' | 'throttled' | 'bounced' | 'sent' | 'failed'
 
 export type CampaignUpdateParams = Partial<Pick<Campaign, 'name' | 'state' | 'list_ids' | 'exclusion_list_ids' | 'subscription_id' | 'tags'>>
-export type CampaignCreateParams = Pick<Campaign, 'name' | 'list_ids' | 'exclusion_list_ids' | 'channel' | 'subscription_id' | 'provider_id' | 'tags'>
+export type CampaignCreateParams = Pick<Campaign, 'name' | 'type' | 'list_ids' | 'exclusion_list_ids' | 'channel' | 'subscription_id' | 'provider_id' | 'tags'>
 export type CampaignLaunchParams = Pick<Campaign, 'send_at' | 'send_in_user_timezone'>
 // export type ListUpdateParams = Pick<List, 'name' | 'rule'>
 export type CampaignUser = User & { state: CampaignSendState, send_at: string }

--- a/apps/ui/src/views/campaign/CampaignDetail.tsx
+++ b/apps/ui/src/views/campaign/CampaignDetail.tsx
@@ -125,7 +125,7 @@ export default function CampaignDetail() {
         <PageContent
             title={name}
             desc={state !== 'draft' && <CampaignTag state={campaign.state} />}
-            actions={action[state]}>
+            actions={campaign.type !== 'trigger' && action[state]}>
             <NavigationTabs tabs={tabs} />
             <LocaleContext.Provider value={[locale, setLocale]}>
                 <Outlet />

--- a/apps/ui/src/views/campaign/CampaignForm.tsx
+++ b/apps/ui/src/views/campaign/CampaignForm.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import api from '../../api'
 import { ProjectContext } from '../../contexts'
-import { Campaign, CampaignCreateParams, List, Project, Provider, SearchParams, Subscription } from '../../types'
+import { Campaign, CampaignCreateParams, CampaignType, List, Project, Provider, SearchParams, Subscription } from '../../types'
 import { useController, UseFormReturn, useWatch } from 'react-hook-form'
 import TextInput from '../../ui/form/TextInput'
 import FormWrapper from '../../ui/form/FormWrapper'
@@ -20,7 +20,7 @@ import { DataTable } from '../../ui/DataTable'
 interface CampaignEditParams {
     campaign?: Campaign
     onSave: (campaign: Campaign) => void
-    disableListSelection?: boolean
+    type?: CampaignType
 }
 
 interface ListSelectionProps extends SelectionProps<CampaignCreateParams> {
@@ -188,7 +188,7 @@ const ProviderSelection = ({ providers, form }: { providers: Provider[], form: U
     )
 }
 
-export function CampaignForm({ campaign, disableListSelection, onSave }: CampaignEditParams) {
+export function CampaignForm({ campaign, type = 'blast', onSave }: CampaignEditParams) {
     const [project] = useContext(ProjectContext)
 
     const [providers, setProviders] = useState<Provider[]>([])
@@ -220,7 +220,7 @@ export function CampaignForm({ campaign, disableListSelection, onSave }: Campaig
         const params = { name, list_ids, exclusion_list_ids, subscription_id, tags }
         const value = campaign
             ? await api.campaigns.update(project.id, campaign.id, params)
-            : await api.campaigns.create(project.id, { channel, provider_id, ...params })
+            : await api.campaigns.create(project.id, { channel, provider_id, type, ...params })
         onSave(value)
     }
 
@@ -242,7 +242,7 @@ export function CampaignForm({ campaign, disableListSelection, onSave }: Campaig
                         name="tags"
                     />
                     {
-                        !disableListSelection && (
+                        type !== 'trigger' && (
                             <>
                                 <Heading size="h3" title="Lists">
                                     Select what lists to send this campaign to and what user lists you want to exclude from getting the campaign.

--- a/apps/ui/src/views/campaign/CampaignOverview.tsx
+++ b/apps/ui/src/views/campaign/CampaignOverview.tsx
@@ -66,6 +66,7 @@ export default function CampaignOverview() {
             >
                 <CampaignForm
                     campaign={campaign}
+                    type={campaign.type}
                     onSave={campaign => {
                         setCampaign(campaign)
                         setIsEditOpen(false)

--- a/apps/ui/src/views/journey/steps/Action.tsx
+++ b/apps/ui/src/views/journey/steps/Action.tsx
@@ -34,7 +34,7 @@ export const actionStep: JourneyStepType<ActionConfig> = {
                 createModalSize="large"
                 renderCreateForm={onCreated => (
                     <CampaignForm
-                        disableListSelection
+                        type="trigger"
                         onSave={onCreated}
                     />
                 )}


### PR DESCRIPTION
Add a campaign `type` field that can be either `blast` or `trigger`. This will allow for better segmenting campaigns associated with journeys and allow for better UI when updating.

blast = one time campaign
trigger = journey campaign

- Fixes a bug where you can "launch" a campaign created from a journey 
- Fixes bug where you can't edit a journey campaigns name without adding a list