### PR TITLE
Improves paging by removing need for counting queries

### DIFF
--- a/apps/platform/@types/knex.d.ts
+++ b/apps/platform/@types/knex.d.ts
@@ -1,0 +1,12 @@
+import { Knex as KnexOriginal } from 'knex'
+declare module 'knex' {
+    namespace Knex {
+        interface QueryInterface {
+            when<TResult>(
+                condition: boolean,
+                fnif: (builder: QueryBuilder<any>) => QueryBuilder<any>,
+                fnelse?: (builder: QueryBuilder<any>) => QueryBuilder<any>,
+            ): KnexOriginal.QueryBuilder<any, TResult>
+        }
+    }
+}

--- a/apps/platform/src/auth/AdminRepository.ts
+++ b/apps/platform/src/auth/AdminRepository.ts
@@ -1,10 +1,9 @@
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { Admin, AdminParams } from './Admin'
 
-export const pagedAdmins = async (params: SearchParams) => {
-    return await Admin.searchParams(
-        params,
-        ['first_name', 'last_name', 'email'],
+export const pagedAdmins = async (params: PageParams) => {
+    return await Admin.search(
+        { ...params, fields: ['first_name', 'last_name', 'email'] },
     )
 }
 

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -9,8 +9,7 @@ import { UserList } from '../lists/List'
 import Subscription from '../subscriptions/Subscription'
 import { RequestError } from '../core/errors'
 import App from '../app'
-
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { allLists } from '../lists/ListService'
 import { allTemplates, duplicateTemplate, validateTemplates } from '../render/TemplateService'
 import { getSubscription } from '../subscriptions/SubscriptionService'
@@ -21,12 +20,11 @@ import { getProject } from '../projects/ProjectService'
 import CampaignError from './CampaignError'
 import CampaignGenerateListJob from './CampaignGenerateListJob'
 
-export const pagedCampaigns = async (params: SearchParams, projectId: number) => {
-    const result = await Campaign.searchParams(
-        params,
-        ['name'],
+export const pagedCampaigns = async (params: PageParams, projectId: number) => {
+    const result = await Campaign.search(
+        { ...params, fields: ['name'] },
         b => {
-            b.where({ project_id: projectId })
+            b.where('project_id', projectId)
                 .whereNull('deleted_at')
             params.tag?.length && b.whereIn('id', createTagSubquery(Campaign, projectId, params.tag))
             return b
@@ -158,10 +156,9 @@ export const deleteCampaign = async (id: number, projectId: number) => {
     return await Campaign.delete(qb => qb.where('id', id).where('project_id', projectId))
 }
 
-export const getCampaignUsers = async (id: number, params: SearchParams, projectId: number) => {
-    return await User.searchParams(
-        params,
-        ['email', 'phone'],
+export const getCampaignUsers = async (id: number, params: PageParams, projectId: number) => {
+    return await User.search(
+        { ...params, fields: ['email', 'phone'], mode: 'exact' },
         b => b.rightJoin('campaign_sends', 'campaign_sends.user_id', 'users.id')
             .where('project_id', projectId)
             .where('campaign_id', id)

--- a/apps/platform/src/config/database.ts
+++ b/apps/platform/src/config/database.ts
@@ -17,6 +17,16 @@ export interface DatabaseConfig {
     connection: DatabaseConnection
 }
 
+export type Query = (builder: Database.QueryBuilder<any>) => Database.QueryBuilder<any>
+
+knex.QueryBuilder.extend('when', function(
+    condition: boolean,
+    fnif: Query,
+    fnelse?: Query,
+) {
+    return condition ? fnif(this) : (fnelse ? fnelse(this) : this)
+})
+
 const connect = (config: DatabaseConfig, withDB = true) => {
     let connection = config.connection
     if (!withDB) {

--- a/apps/platform/src/core/searchParams.ts
+++ b/apps/platform/src/core/searchParams.ts
@@ -1,29 +1,40 @@
 import { JSONSchemaType } from 'ajv'
+import Model from './Model'
 
-export interface SearchParams {
-    page: number
-    itemsPerPage: number
-    q?: string
+export interface PageParams {
+    limit: number
     sort?: string
     direction?: string
+    cursor?: string
+    page?: 'prev' | 'next'
+    q?: string
     tag?: string[]
     id?: number[]
 }
 
-export const SearchSchema = (id: string, defaults?: Partial<SearchParams>): JSONSchemaType<SearchParams> => {
+export interface PageQueryParams<T extends typeof Model> extends PageParams {
+    fields?: Array<keyof InstanceType<T> | string>
+    mode?: 'exact' | 'partial'
+}
+
+export const SearchSchema = (id: string, defaults?: Partial<PageParams>): JSONSchemaType<PageParams> => {
     return {
         $id: id,
         type: 'object',
-        required: ['page', 'itemsPerPage'],
+        required: ['limit'],
         properties: {
-            page: {
-                type: 'integer',
-                default: defaults?.page ?? 0,
-                minimum: 0,
+            cursor: {
+                type: 'string',
+                nullable: true,
             },
-            itemsPerPage: {
+            page: {
+                type: 'string',
+                enum: ['prev', 'next'],
+                nullable: true,
+            },
+            limit: {
                 type: 'integer',
-                default: defaults?.itemsPerPage ?? 25,
+                default: defaults?.limit ?? 25,
                 minimum: -1, // -1 for all
             },
             q: {
@@ -60,4 +71,4 @@ export const SearchSchema = (id: string, defaults?: Partial<SearchParams>): JSON
     }
 }
 
-export const searchParamsSchema: JSONSchemaType<SearchParams> = SearchSchema('searchParams')
+export const searchParamsSchema: JSONSchemaType<PageParams> = SearchSchema('searchParams')

--- a/apps/platform/src/journey/JourneyRepository.ts
+++ b/apps/platform/src/journey/JourneyRepository.ts
@@ -1,16 +1,15 @@
 import App from '../app'
 import { Database } from 'config/database'
 import { RequestError } from '../core/errors'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import Journey, { JourneyParams, UpdateJourneyParams } from './Journey'
 import { JourneyStep, JourneyEntrance, JourneyUserStep, JourneyStepMap, toJourneyStepMap, JourneyStepChild } from './JourneyStep'
 import { raw } from '../core/Model'
 import { createTagSubquery, getTags, setTags } from '../tags/TagService'
 
-export const pagedJourneys = async (params: SearchParams, projectId: number) => {
-    const result = await Journey.searchParams(
-        params,
-        ['name'],
+export const pagedJourneys = async (params: PageParams, projectId: number) => {
+    const result = await Journey.search(
+        { ...params, fields: ['name'] },
         b => {
             b = b.where({ project_id: projectId })
             params.tag?.length && b.whereIn('id', createTagSubquery(Journey, projectId, params.tag))

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -4,17 +4,16 @@ import { check, query as ruleQuery } from '../rules/RuleEngine'
 import List, { DynamicList, ListCreateParams, UserList } from './List'
 import Rule from '../rules/Rule'
 import { enterJourneyFromList } from '../journey/JourneyService'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import App from '../app'
 import ListPopulateJob from './ListPopulateJob'
 import { importUsers } from '../users/UserImport'
 import { FileStream } from '../storage/FileStream'
 import { createTagSubquery, getTags, setTags } from '../tags/TagService'
 
-export const pagedLists = async (params: SearchParams, projectId: number) => {
-    const result = await List.searchParams(
-        params,
-        ['name'],
+export const pagedLists = async (params: PageParams, projectId: number) => {
+    const result = await List.search(
+        { ...params, fields: ['name'] },
         b => {
             b = b.where('project_id', projectId)
                 .whereNull('deleted_at')
@@ -58,10 +57,9 @@ export const getList = async (id: number, projectId: number) => {
     return list
 }
 
-export const getListUsers = async (id: number, params: SearchParams, projectId: number) => {
-    return await User.searchParams(
-        params,
-        ['email', 'phone'],
+export const getListUsers = async (id: number, params: PageParams, projectId: number) => {
+    return await User.search(
+        { ...params, fields: ['email', 'phone'], mode: 'exact' },
         b => b.rightJoin('user_list', 'user_list.user_id', 'users.id')
             .where('project_id', projectId)
             .where('list_id', id)
@@ -69,10 +67,9 @@ export const getListUsers = async (id: number, params: SearchParams, projectId: 
     )
 }
 
-export const getUserLists = async (id: number, params: SearchParams, projectId: number) => {
-    return await List.searchParams(
+export const getUserLists = async (id: number, params: PageParams, projectId: number) => {
+    return await List.search(
         params,
-        [],
         b => b.rightJoin('user_list', 'user_list.list_id', 'lists.id')
             .where('project_id', projectId)
             .where('user_id', id)

--- a/apps/platform/src/projects/ProjectAdminRepository.ts
+++ b/apps/platform/src/projects/ProjectAdminRepository.ts
@@ -1,5 +1,5 @@
 import { Database } from 'config/database'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { ProjectRole } from './Project'
 import { ProjectAdmin } from './ProjectAdmins'
 
@@ -14,10 +14,9 @@ const baseProjectAdminQuery = (builder: Database.QueryBuilder<any>, projectId: n
         .whereNull(`${ProjectAdmin.tableName}.deleted_at`)
 }
 
-export const pagedProjectAdmins = async (params: SearchParams, projectId: number) => {
-    return await ProjectAdmin.searchParams(
-        params,
-        adminSelectFields,
+export const pagedProjectAdmins = async (params: PageParams, projectId: number) => {
+    return await ProjectAdmin.search(
+        { ...params, fields: adminSelectFields },
         q => baseProjectAdminQuery(q, projectId),
     )
 }

--- a/apps/platform/src/projects/ProjectService.ts
+++ b/apps/platform/src/projects/ProjectService.ts
@@ -1,7 +1,7 @@
-import { ProjectState } from 'auth/AuthMiddleware'
+import { ProjectState } from '../auth/AuthMiddleware'
 import { Next, ParameterizedContext } from 'koa'
 import { RequestError } from '../core/errors'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { createSubscription } from '../subscriptions/SubscriptionService'
 import { uuid } from '../utilities'
 import Project, { ProjectParams, ProjectRole, projectRoles } from './Project'
@@ -15,10 +15,10 @@ export const adminProjectIds = async (adminId: number) => {
     return records.map(item => item.project_id)
 }
 
-export const pagedProjects = async (params: SearchParams, adminId: number) => {
+export const pagedProjects = async (params: PageParams, adminId: number) => {
     const admin = await getAdmin(adminId)
     const projectIds = await adminProjectIds(adminId)
-    return await Project.searchParams(params, ['name'], qb =>
+    return await Project.search({ ...params, fields: ['name'] }, qb =>
         qb.where(qb =>
             qb.where('organization_id', admin!.organization_id)
                 .orWhereIn('projects.id', projectIds),
@@ -79,10 +79,9 @@ export const updateProject = async (id: number, adminId: number, params: Partial
     return await getProject(id, adminId)
 }
 
-export const pagedApiKeys = async (params: SearchParams, projectId: number) => {
-    return await ProjectApiKey.searchParams(
-        params,
-        ['name', 'description'],
+export const pagedApiKeys = async (params: PageParams, projectId: number) => {
+    return await ProjectApiKey.search(
+        { ...params, fields: ['name', 'description'] },
         qb => qb.where('project_id', projectId),
     )
 }

--- a/apps/platform/src/providers/ProviderService.ts
+++ b/apps/platform/src/providers/ProviderService.ts
@@ -1,6 +1,6 @@
 import Router from '@koa/router'
 import { ProjectState } from '../auth/AuthMiddleware'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { JSONSchemaType, validate } from '../core/validate'
 import Provider, { ProviderControllers, ProviderGroup, ProviderMeta, ProviderParams } from './Provider'
 import { createProvider, loadProvider, updateProvider } from './ProviderRepository'
@@ -9,11 +9,10 @@ export const allProviders = async (projectId: number) => {
     return await Provider.all(qb => qb.where('project_id', projectId))
 }
 
-export const pagedProviders = async (params: SearchParams, projectId: number) => {
-    return await Provider.searchParams(
-        params,
-        ['name', 'group'],
-        b => b.where({ project_id: projectId }),
+export const pagedProviders = async (params: PageParams, projectId: number) => {
+    return await Provider.search(
+        { ...params, fields: ['name', 'group'] },
+        b => b.where('project_id', projectId),
     )
 }
 

--- a/apps/platform/src/render/TemplateService.ts
+++ b/apps/platform/src/render/TemplateService.ts
@@ -1,4 +1,4 @@
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import Template, { TemplateParams, TemplateType, TemplateUpdateParams } from './Template'
 import { pick, prune } from '../utilities'
 import { Variables } from '.'
@@ -13,11 +13,10 @@ import { loadPushChannel } from '../providers/push'
 import { getUserFromEmail, getUserFromPhone } from '../users/UserRepository'
 import { loadWebhookChannel } from '../providers/webhook'
 
-export const pagedTemplates = async (params: SearchParams, projectId: number) => {
-    return await Template.searchParams(
+export const pagedTemplates = async (params: PageParams, projectId: number) => {
+    return await Template.search(
         params,
-        [],
-        b => b.where({ project_id: projectId }),
+        b => b.where('project_id', projectId),
     )
 }
 

--- a/apps/platform/src/render/TemplateService.ts
+++ b/apps/platform/src/render/TemplateService.ts
@@ -16,7 +16,7 @@ import { loadWebhookChannel } from '../providers/webhook'
 export const pagedTemplates = async (params: PageParams, projectId: number) => {
     return await Template.search(
         params,
-        b => b.where('project_id', projectId),
+        qb => qb.where('project_id', projectId),
     )
 }
 

--- a/apps/platform/src/storage/ImageController.ts
+++ b/apps/platform/src/storage/ImageController.ts
@@ -5,7 +5,7 @@ import { getImage, pagedImages, updateImage, uploadImage } from './ImageService'
 import Image, { ImageParams } from './Image'
 import { ProjectState } from '../auth/AuthMiddleware'
 import { extractQueryParams } from '../utilities'
-import { searchParamsSchema } from '../core/searchParams'
+import { SearchSchema } from '../core/searchParams'
 
 const router = new Router<
     ProjectState & { image?: Image }
@@ -45,7 +45,11 @@ router.post('/', async ctx => {
 })
 
 router.get('/', async ctx => {
-    const params = extractQueryParams(ctx.query, searchParamsSchema)
+    const searchSchema = SearchSchema('imagesSearchSchema', {
+        sort: 'id',
+        direction: 'desc',
+    })
+    const params = extractQueryParams(ctx.query, searchSchema)
     ctx.body = await pagedImages(params, ctx.state.project.id)
 })
 

--- a/apps/platform/src/storage/ImageService.ts
+++ b/apps/platform/src/storage/ImageService.ts
@@ -2,7 +2,7 @@ import App from '../app'
 import { snakeCase } from '../utilities'
 import Image, { ImageParams } from './Image'
 import { FileStream } from './FileStream'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 
 export const uploadImage = async (projectId: number, stream: FileStream): Promise<Image> => {
     const upload = await App.main.storage.save(stream)
@@ -17,11 +17,10 @@ export const allImages = async (projectId: number): Promise<Image[]> => {
     return await Image.all(qb => qb.where('project_id', projectId))
 }
 
-export const pagedImages = async (params: SearchParams, projectId: number) => {
-    return await Image.searchParams(
-        params,
-        ['name'],
-        b => b.where('project_id', projectId).orderBy('created_at', 'desc'),
+export const pagedImages = async (params: PageParams, projectId: number) => {
+    return await Image.search(
+        { ...params, fields: ['name'] },
+        b => b.where('project_id', projectId),
     )
 }
 

--- a/apps/platform/src/subscriptions/SubscriptionService.ts
+++ b/apps/platform/src/subscriptions/SubscriptionService.ts
@@ -1,6 +1,6 @@
 import { TextProvider } from '../providers/text/TextProvider'
 import { ChannelType } from '../config/channels'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { paramsToEncodedLink, TrackedLinkParams } from '../render/LinkService'
 import { User } from '../users/User'
 import { createEvent } from '../users/UserEventRepository'
@@ -9,18 +9,16 @@ import Subscription, { SubscriptionParams, SubscriptionState, UserSubscription }
 import App from '../app'
 import { combineURLs, encodeHashid } from '../utilities'
 
-export const pagedSubscriptions = async (params: SearchParams, projectId: number) => {
-    return await Subscription.searchParams(
-        params,
-        ['name', 'channel'],
+export const pagedSubscriptions = async (params: PageParams, projectId: number) => {
+    return await Subscription.search(
+        { ...params, fields: ['name', 'channel'] },
         qb => qb.where('project_id', projectId),
     )
 }
 
-export const getUserSubscriptions = async (id: number, params: SearchParams, projectId: number) => {
-    return await UserSubscription.searchParams(
-        params,
-        ['name', 'channel'],
+export const getUserSubscriptions = async (id: number, params: PageParams, projectId: number) => {
+    return await UserSubscription.search(
+        { ...params, fields: ['name', 'channel'] },
         b => b.leftJoin('subscriptions', 'subscriptions.id', 'user_subscription.subscription_id')
             .where('project_id', projectId)
             .where('user_id', id)

--- a/apps/platform/src/tags/TagController.ts
+++ b/apps/platform/src/tags/TagController.ts
@@ -17,9 +17,10 @@ const router = new Router<
 })
 
 router.get('/', async ctx => {
-    ctx.body = await Tag.searchParams(
-        extractQueryParams(ctx.request.query, searchParamsSchema),
-        ['name'],
+    const params = extractQueryParams(ctx.request.query, searchParamsSchema)
+    ctx.body = await Tag.search(
+        { ...params, fields: ['name'] },
+        qb => qb.where('project_id', ctx.state.project!.id),
     )
 })
 

--- a/apps/platform/src/users/UserEventRepository.ts
+++ b/apps/platform/src/users/UserEventRepository.ts
@@ -1,4 +1,4 @@
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { loadAnalytics } from '../providers/analytics'
 import { User } from '../users/User'
 import { UserEvent, UserEventParams } from './UserEvent'
@@ -27,10 +27,9 @@ export const createAndFetchEvent = async (user: User, event: UserEventParams, fo
     return userEvent!
 }
 
-export const getUserEvents = async (id: number, params: SearchParams, projectId: number) => {
-    return await UserEvent.searchParams(
-        params,
-        ['name'],
+export const getUserEvents = async (id: number, params: PageParams, projectId: number) => {
+    return await UserEvent.search(
+        { ...params, fields: ['name'] },
         b => b.where('project_id', projectId)
             .where('user_id', id)
             .orderBy('id', 'desc'),

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -1,5 +1,5 @@
 import { ClientAliasParams, ClientIdentity } from '../client/Client'
-import { SearchParams } from '../core/searchParams'
+import { PageParams } from '../core/searchParams'
 import { subscribeAll } from '../subscriptions/SubscriptionService'
 import { Device, DeviceParams, User, UserParams } from '../users/User'
 import { uuid } from '../utilities'
@@ -40,11 +40,14 @@ export const getUserFromEmail = async (projectId: number, email: string): Promis
     )
 }
 
-export const pagedUsers = async (params: SearchParams, projectId: number) => {
-    return await User.searchParams(
-        params,
-        ['external_id', 'email', 'phone'],
-        b => b.where({ project_id: projectId }),
+export const pagedUsers = async (params: PageParams, projectId: number) => {
+    return await User.search(
+        {
+            ...params,
+            fields: ['external_id', 'email', 'phone'],
+            mode: 'exact',
+        },
+        b => b.where('project_id', projectId),
     )
 }
 

--- a/apps/platform/tsconfig.json
+++ b/apps/platform/tsconfig.json
@@ -4,10 +4,15 @@
     "module": "commonjs",                        
     "moduleResolution": "node",
     "baseUrl": "./src",
-    "outDir": "./build"
+    "outDir": "./build",
+    "typeRoots": [
+      "node_modules/@types",
+      "@types"
+    ]
   },
   "include": [
     "./src/**/*",
+    "@types",
     "tsconfig.json"
   ],
   "exclude": [

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -78,23 +78,21 @@ export interface Preferences {
 }
 
 export interface SearchParams {
-    page: number
-    itemsPerPage: number
-    q?: string
+    cursor?: string
+    page?: 'next' | 'prev'
+    limit: number
     sort?: string
     direction?: string
+    q?: string
     tag?: string[]
     id?: Array<number | string>
 }
 
 export interface SearchResult<T> {
     results: T[]
-    start: number
-    end: number
-    total: number
-    page: number
-    itemsPerPage: number
-    pages: number
+    nextCursor: string
+    prevCursor?: string
+    limit: number
 }
 
 export type AuditFields = 'created_at' | 'updated_at' | 'deleted_at'

--- a/apps/ui/src/ui/Pagination.tsx
+++ b/apps/ui/src/ui/Pagination.tsx
@@ -3,7 +3,7 @@ import './Pagination.css'
 
 interface PaginationProps {
     prevCursor: string | undefined
-    nextCursor: string
+    nextCursor: string | undefined
     onPrev: (cursor: string | undefined) => void
     onNext: (cursor: string | undefined) => void
 }
@@ -14,6 +14,7 @@ export default function CursorPagination({
     onPrev,
     onNext,
 }: PaginationProps) {
+    if (!prevCursor && !nextCursor) return <></>
     return (
         <div className="ui-pagination">
             <button className="pagination-button prev"
@@ -23,7 +24,7 @@ export default function CursorPagination({
                 Previous
             </button>
             <button className="pagination-button next"
-                // disabled={nextCursor}
+                disabled={nextCursor === undefined}
                 onClick={() => onNext(nextCursor)}>
                 Next
                 <ChevronRightIcon />

--- a/apps/ui/src/ui/Pagination.tsx
+++ b/apps/ui/src/ui/Pagination.tsx
@@ -2,99 +2,29 @@ import { ChevronLeftIcon, ChevronRightIcon } from './icons'
 import './Pagination.css'
 
 interface PaginationProps {
-    itemsPerPage: number
-    onChangePage: (page: number) => void
-    page: number
-    total: number
+    prevCursor: string | undefined
+    nextCursor: string
+    onPrev: (cursor: string | undefined) => void
+    onNext: (cursor: string | undefined) => void
 }
 
-type Page = number | '...'
-
-export default function Pagination({
-    onChangePage,
-    page = 0,
-    total = 0,
+export default function CursorPagination({
+    prevCursor,
+    nextCursor,
+    onPrev,
+    onNext,
 }: PaginationProps) {
-
-    if (total == null) return null
-
-    const pageCount = Math.max(0, total)
-
-    if (pageCount <= 1) return null
-
-    const getRange = (start: number, end: number) => {
-        return Array(end - start + 1)
-            .fill(0)
-            .map((_, i) => i + start)
-    }
-
-    const pagination = (currentPage: number, pageCount: number): Page[] => {
-        let delta: number
-        if (pageCount <= 7) {
-            // delta === 7: [1 2 3 4 5 6 7]
-            delta = 7
-        } else {
-            // delta === 2: [1 ... 4 5 6 ... 10]
-            // delta === 4: [1 2 3 4 5 ... 10]
-            delta = currentPage > 4 && currentPage < pageCount - 3 ? 2 : 4
-        }
-
-        const range = {
-            start: Math.round(currentPage - delta / 2),
-            end: Math.round(currentPage + delta / 2),
-        }
-
-        if (range.start - 1 === 1 || range.end + 1 === pageCount) {
-            range.start += 1
-            range.end += 1
-        }
-
-        let pages: Page[] = currentPage > delta
-            ? getRange(Math.min(range.start, pageCount - delta), Math.min(range.end, pageCount))
-            : getRange(1, Math.min(pageCount, delta + 1))
-
-        const withDots = (value: number, pair: Page[]) => (pages.length + 1 !== pageCount ? pair : [value])
-
-        if (pages[0] !== 1) {
-            pages = withDots(1, [1, '...']).concat(pages)
-        }
-
-        if (pages[pages.length - 1] < pageCount) {
-            pages = pages.concat(withDots(pageCount, ['...', pageCount]))
-        }
-
-        return pages
-    }
-
-    const pages = pagination(page, pageCount)
-
-    const Page = ({ index }: { index: number }) => {
-        const currPage = index - 1
-        return <button
-            onClick={() => onChangePage(currPage)}
-            className={`pagination-button ${currPage === page ? 'selected' : ''}`} key={index}>
-            {index.toLocaleString()}
-        </button>
-    }
-
     return (
         <div className="ui-pagination">
             <button className="pagination-button prev"
-                disabled={page <= 0}
-                onClick={() => onChangePage(page - 1)}>
+                disabled={prevCursor === undefined}
+                onClick={() => onPrev(prevCursor)}>
                 <ChevronLeftIcon />
                 Previous
             </button>
-            {
-                pages.map((curr, index) => (
-                    curr === '...'
-                        ? <div className="spacer" key={index}>{curr}</div>
-                        : <Page index={curr} key={index} />
-                ))
-            }
             <button className="pagination-button next"
-                disabled={(page + 1) >= total}
-                onClick={() => onChangePage(page + 1)}>
+                // disabled={nextCursor}
+                onClick={() => onNext(nextCursor)}>
                 Next
                 <ChevronRightIcon />
             </button>

--- a/apps/ui/src/ui/SearchTable.tsx
+++ b/apps/ui/src/ui/SearchTable.tsx
@@ -26,10 +26,11 @@ export interface SearchTableProps<T extends Record<string, any>> extends Omit<Da
 const DEFAULT_ITEMS_PER_PAGE = 25
 const DEFAULT_PAGE = 0
 
-const toTableParams = (searchParams: URLSearchParams) => {
+const toTableParams = (searchParams: URLSearchParams): SearchParams => {
     return {
-        page: parseInt(searchParams.get('page') ?? '0'),
-        itemsPerPage: parseInt(searchParams.get('itemsPerPage') ?? '10'),
+        cursor: searchParams.get('cursor') ?? undefined,
+        page: searchParams.get('page') === 'prev' ? 'prev' : 'next',
+        limit: parseInt(searchParams.get('limit') ?? '25'),
         q: searchParams.get('q') ?? undefined,
         tag: searchParams.getAll('tag'),
         sort: searchParams.get('sort') ?? undefined,
@@ -39,8 +40,9 @@ const toTableParams = (searchParams: URLSearchParams) => {
 
 const fromTableParams = (params: SearchParams): Record<string, string> => {
     return prune({
-        page: params.page.toString(),
-        itemsPerPage: params.itemsPerPage.toString(),
+        cursor: params.cursor,
+        page: params.page,
+        limit: params.limit.toString(),
         q: params.q,
         tag: params.tag ?? [],
         sort: params.sort,
@@ -74,8 +76,7 @@ export const useTableSearchParams = () => {
 export function useSearchTableState<T>(loader: (params: SearchParams) => Promise<SearchResult<T> | null>) {
 
     const [params, setParams] = useState<SearchParams>({
-        page: 0,
-        itemsPerPage: 25,
+        limit: 25,
         q: '',
     })
 
@@ -189,10 +190,10 @@ export function SearchTable<T extends Record<string, any>>({
                 }} />
             {results && (
                 <Pagination
-                    page={results.page}
-                    total={results.pages}
-                    itemsPerPage={results.itemsPerPage}
-                    onChangePage={page => setParams({ ...params, page })} />
+                    nextCursor={results.nextCursor}
+                    prevCursor={results.prevCursor}
+                    onPrev={cursor => setParams({ ...params, cursor, page: 'prev' })}
+                    onNext={cursor => setParams({ ...params, cursor, page: 'next' })} />
             )}
         </>
     )

--- a/apps/ui/src/ui/Sidebar.tsx
+++ b/apps/ui/src/ui/Sidebar.tsx
@@ -33,8 +33,7 @@ export default function Sidebar({ children, links }: PropsWithChildren<SidebarPr
         const recents: Array<typeof project> = []
         if (recentIds.length) {
             const projects = await api.projects.search({
-                page: 0,
-                itemsPerPage: recentIds.length,
+                limit: recentIds.length,
                 id: recentIds,
             }).then(r => r.results ?? [])
             for (const id of recentIds) {

--- a/apps/ui/src/views/campaign/CampaignForm.tsx
+++ b/apps/ui/src/views/campaign/CampaignForm.tsx
@@ -194,7 +194,7 @@ export function CampaignForm({ campaign, type = 'blast', onSave }: CampaignEditP
     const [providers, setProviders] = useState<Provider[]>([])
     const [subscriptions, setSubscriptions] = useState<Subscription[]>([])
     useEffect(() => {
-        const params: SearchParams = { page: 0, itemsPerPage: 9999, q: '' }
+        const params: SearchParams = { limit: 9999, q: '' }
         api.subscriptions.search(project.id, params)
             .then(({ results }) => {
                 setSubscriptions(results)

--- a/apps/ui/src/views/journey/steps/Action.tsx
+++ b/apps/ui/src/views/journey/steps/Action.tsx
@@ -27,7 +27,7 @@ export const actionStep: JourneyStepType<ActionConfig> = {
                 label="Campaign"
                 subtitle="Send this campaign when users reach this step."
                 get={useCallback(async id => await api.campaigns.get(projectId, id), [projectId])}
-                search={useCallback(async q => await api.campaigns.search(projectId, { q, page: 0, itemsPerPage: 50 }), [projectId])}
+                search={useCallback(async q => await api.campaigns.search(projectId, { q, limit: 50 }), [projectId])}
                 value={value.campaign_id}
                 onChange={campaign_id => onChange({ ...value, campaign_id })}
                 required

--- a/apps/ui/src/views/journey/steps/Entrance.tsx
+++ b/apps/ui/src/views/journey/steps/Entrance.tsx
@@ -25,7 +25,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
         value,
     }) {
         const getList = useCallback(async (id: number) => await api.lists.get(projectId, id), [projectId])
-        const searchLists = useCallback(async (q: string) => await api.lists.search(projectId, { q, page: 0, itemsPerPage: 50 }), [projectId])
+        const searchLists = useCallback(async (q: string) => await api.lists.search(projectId, { q, limit: 50 }), [projectId])
         return (
             <EntityIdPicker
                 label="List"

--- a/apps/ui/src/views/journey/steps/JourneyLink.tsx
+++ b/apps/ui/src/views/journey/steps/JourneyLink.tsx
@@ -26,7 +26,7 @@ export const journeyLinkStep: JourneyStepType<JourneyLinkConfig> = {
                 label="Target Journey"
                 subtitle="Send users to this journey when they reach this step."
                 get={useCallback(async id => await api.journeys.get(project.id, id), [project])}
-                search={useCallback(async q => await api.journeys.search(project.id, { q, page: 0, itemsPerPage: 50 }), [project])}
+                search={useCallback(async q => await api.journeys.search(project.id, { q, limit: 50 }), [project])}
                 optionEnabled={o => o.id !== journey.id}
                 value={value.target_id}
                 onChange={target_id => onChange({ ...value, target_id })}

--- a/apps/ui/src/views/settings/Teams.tsx
+++ b/apps/ui/src/views/settings/Teams.tsx
@@ -19,7 +19,7 @@ export default function Teams() {
     const [project] = useContext(ProjectContext)
     const state = useSearchTableState(useCallback(async params => await api.projectAdmins.search(project.id, params), [project]))
     const [editing, setEditing] = useState<null | Partial<EditFormData>>(null)
-    const searchAdmins = useCallback(async (q: string) => await api.admins.search({ q, page: 0, itemsPerPage: 100 }), [])
+    const searchAdmins = useCallback(async (q: string) => await api.admins.search({ q, limit: 100 }), [])
 
     return (
         <>

--- a/apps/ui/src/views/users/UserDetailEvents.tsx
+++ b/apps/ui/src/views/users/UserDetailEvents.tsx
@@ -11,8 +11,7 @@ export default function UserDetailEvents() {
     const [project] = useContext(ProjectContext)
     const [user] = useContext(UserContext)
     const [params, setParams] = useState<SearchParams>({
-        page: 0,
-        itemsPerPage: 10,
+        limit: 25,
         q: '',
     })
     const projectId = project.id


### PR DESCRIPTION
Overall performance improvement as counting total number of results was getting quite slow for many views. This removes that need and switches entirely to cursor based paging with support for both going backwards and sorting.

- Removes counting total results when doing paging
- Adds `exact` and `partial` searching to improve performance for some views
- Allows for single column sorting of results and cursor paging backwards

Completes PV-12, PV-51