### PR TITLE
Event names are not causing lists to trigger

### DIFF
--- a/apps/platform/src/rules/WrapperRule.ts
+++ b/apps/platform/src/rules/WrapperRule.ts
@@ -9,7 +9,12 @@ export default {
 
         // If wrapper is for events, evaluate event name alongside conditions
         if (isEventWrapper(rule)) {
-            const nameRule = make({ type: 'string', path: '$.name', value: rule.value })
+            const nameRule = make({
+                type: 'string',
+                path: '$.name',
+                value: rule.value,
+                group: 'event',
+            })
             if (!registry.get('string').check(input, nameRule, registry)) return false
         }
 

--- a/apps/platform/src/rules/__test__/RuleEngine.spec.ts
+++ b/apps/platform/src/rules/__test__/RuleEngine.spec.ts
@@ -2,6 +2,25 @@ import { subDays } from 'date-fns'
 import { check, make } from '../RuleEngine'
 
 describe('RuleEngine', () => {
+    describe('wrapper', () => {
+        test('event name match', () => {
+            const name = 'Account Created'
+            const value = {
+                user: {
+                    id: 'abcd',
+                },
+                event: {
+                    name,
+                },
+            }
+            const shouldPass = check(value, [
+                make({ type: 'wrapper', path: '$.name', value: name }),
+            ])
+
+            expect(shouldPass).toBeTruthy()
+        })
+    })
+
     describe('string', () => {
         test('equals', () => {
             const email = 'test@test.com'


### PR DESCRIPTION
This resolves two bugs related to user events triggering lists:
- If any list has logic that could cause the rule check to fail all subsequent checks end up being skipped
- Rule checking just for an event name doesn't work properly because it's defaulting to a user check vs event check