### PR TITLE
Only send pushes to users with devices

### DIFF
--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -339,6 +339,8 @@ export const recipientQuery = (campaign: Campaign) => {
                 qb.whereNotNull('users.email')
             } else if (campaign.channel === 'text') {
                 qb.whereNotNull('users.phone')
+            } else if (campaign.channel === 'push') {
+                qb.whereNotNull('users.devices')
             }
         })
 }


### PR DESCRIPTION
Reduce the send pool by preemptively filtering users out before trying to send