### PR TITLE
Fixes problem preventing API keys from working

### DIFF
--- a/apps/platform/src/auth/AuthMiddleware.ts
+++ b/apps/platform/src/auth/AuthMiddleware.ts
@@ -70,9 +70,10 @@ export async function authMiddleware(ctx: Context, next: () => void) {
     return next()
 }
 
-export const scopeMiddleware = (scope: string) => {
+export const scopeMiddleware = (scope: string | string[]) => {
+    const scopes = Array.isArray(scope) ? scope : [scope]
     return async function authMiddleware(ctx: Context, next: () => void) {
-        if (ctx.state.scope !== scope) {
+        if (!scopes.includes(ctx.state.scope)) {
             throw new RequestError(AuthError.AccessDenied)
         }
         return next()

--- a/apps/platform/src/config/controllers.ts
+++ b/apps/platform/src/config/controllers.ts
@@ -61,7 +61,7 @@ export default (app: App) => {
 export const adminRouter = () => {
     const admin = new Router({ prefix: '/admin' })
     admin.use(authMiddleware)
-    admin.use(scopeMiddleware('admin'))
+    admin.use(scopeMiddleware(['admin', 'secret']))
     return register(admin,
         ProjectController,
         projectRouter(),


### PR DESCRIPTION
Scoping was preventing secret API keys from ever working with private endpoints. Secret API keys should have roughly the same access as an admin would. Will need to introduce organization level permissions in the future.