### PR TITLE
Forces casting to better utilize indexes

### DIFF
--- a/apps/platform/src/users/UserImport.ts
+++ b/apps/platform/src/users/UserImport.ts
@@ -28,7 +28,7 @@ export const importUsers = async ({ project_id, stream, list_id }: UserImport) =
         chunks.push(UserPatchJob.from({
             project_id,
             user: {
-                external_id,
+                external_id: `${external_id}`,
                 email,
                 phone,
                 timezone,

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -16,14 +16,17 @@ export const getUser = async (id: number, projectId?: number): Promise<User | un
 }
 
 export const getUsersFromIdentity = async (projectId: number, identity: ClientIdentity) => {
+    const externalId = `${identity.external_id}`
+    const anonymousId = `${identity.anonymous_id}`
+
     const users = await User.all(
         qb => qb
             .where(sqb => {
                 if (identity.external_id) {
-                    sqb.where('external_id', `${identity.external_id}`)
+                    sqb.where('external_id', externalId)
                 }
                 if (identity.anonymous_id) {
-                    sqb.orWhere('anonymous_id', `${identity.anonymous_id}`)
+                    sqb.orWhere('anonymous_id', anonymousId)
                 }
             })
             .where('project_id', projectId)
@@ -32,8 +35,8 @@ export const getUsersFromIdentity = async (projectId: number, identity: ClientId
 
     // Map each ID to a key so they are both available
     return {
-        anonymous: users.find(user => user.anonymous_id === identity.anonymous_id),
-        external: users.find(user => user.external_id === identity.external_id),
+        anonymous: users.find(user => user.anonymous_id === anonymousId),
+        external: users.find(user => user.external_id === externalId),
     }
 }
 


### PR DESCRIPTION
MySQL does a terrible job at fully utilizing indexes when there is a type mismatch. If the external ID being provided by the client is a number, it wont be able to lookup the value fully utilizing the index. Currently the CSV parser will automatically cast external ID to a number if it interprets it as being one. This closes that loophole and also forces all comparisons to be string when performing a user lookup to avoid insert collisions in patch job