### PR TITLE
Moves gates to use lists

### DIFF
--- a/apps/platform/db/migrations/20230627184626_journey_step_gate_migration.js
+++ b/apps/platform/db/migrations/20230627184626_journey_step_gate_migration.js
@@ -1,0 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const crypto = require('crypto')
+
+exports.up = async function(knex) {
+    await knex.schema.table('lists', function(table) {
+        table.boolean('is_visible').defaultTo(true)
+    })
+
+    // Update all existing journey steps to have a list_id
+    const gates = await knex('journey_steps').where('type', 'gate')
+    for (const gate of gates) {
+        const journey = await knex('journeys').where('id', gate.journey_id).first()
+        const [id] = await knex('lists').insert({
+            project_id: journey.project_id,
+            name: crypto.randomUUID(),
+            type: 'dynamic',
+            state: 'ready',
+            rule: gate.rule,
+            version: 0,
+            is_visible: false,
+            users_count: 0,
+        })
+        await knex('journey_steps').update({ data: JSON.stringify({ list_id: id }) }).where('id', gate.id)
+    }
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('lists', function(table) {
+        table.dropColumn('is_visible')
+    })
+}

--- a/apps/platform/src/lists/List.ts
+++ b/apps/platform/src/lists/List.ts
@@ -13,6 +13,7 @@ export default class List extends Model {
     version!: number
     users_count?: number
     tags?: string[]
+    is_visible!: boolean
     deleted_at?: Date
 
     static jsonAttributes = ['rule']
@@ -31,4 +32,4 @@ export class UserList extends Model {
 }
 
 export type ListUpdateParams = Pick<List, 'name' | 'rule' | 'tags'>
-export type ListCreateParams = Pick<List, 'name' | 'type' | 'rule' | 'tags'>
+export type ListCreateParams = Pick<List, 'name' | 'type' | 'rule' | 'tags' | 'is_visible'>

--- a/apps/platform/src/lists/ListController.ts
+++ b/apps/platform/src/lists/ListController.ts
@@ -70,6 +70,10 @@ const listParams: JSONSchemaType<ListCreateParams> = {
                 },
                 nullable: true,
             },
+            is_visible: {
+                type: 'boolean',
+                nullable: true,
+            },
         },
         additionalProperties: false,
     },
@@ -89,6 +93,10 @@ const listParams: JSONSchemaType<ListCreateParams> = {
                 items: {
                     type: 'string',
                 },
+                nullable: true,
+            },
+            is_visible: {
+                type: 'boolean',
                 nullable: true,
             },
         },

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -205,6 +205,7 @@ export type List = {
     rule?: WrapperRule
     users_count: number
     tags?: string[]
+    is_visible: boolean
     created_at: string
     updated_at: string
 } & (
@@ -217,7 +218,7 @@ export type List = {
 
 export type DynamicList = List & { type: 'dynamic' }
 
-export type ListCreateParams = Pick<List, 'name' | 'rule' | 'type' | 'tags'>
+export type ListCreateParams = Pick<List, 'name' | 'rule' | 'type' | 'tags' | 'is_visible'>
 export type ListUpdateParams = Pick<List, 'name' | 'rule' | 'tags'>
 
 export interface Journey {

--- a/apps/ui/src/views/journey/steps/Gate.tsx
+++ b/apps/ui/src/views/journey/steps/Gate.tsx
@@ -1,9 +1,12 @@
-import { JourneyStepType, Rule, WrapperRule } from '../../../types'
+import { useCallback } from 'react'
+import { JourneyStepType } from '../../../types'
 import { GateStepIcon } from '../../../ui/icons'
-import RuleBuilder, { createWrapperRule } from '../../users/RuleBuilder'
+import api from '../../../api'
+import { EntityIdPicker } from '../../../ui/form/EntityIdPicker'
+import { ListCreateForm } from '../../users/ListCreateForm'
 
 interface GateConfig {
-    rule: Rule
+    list_id: number
 }
 
 export const gateStep: JourneyStepType<GateConfig> = {
@@ -12,17 +15,32 @@ export const gateStep: JourneyStepType<GateConfig> = {
     category: 'flow',
     description: 'Proceed on different paths depending on condition results.',
     newData: async () => ({
-        rule: createWrapperRule(),
+        list_id: 0,
     }),
     Edit({
         onChange,
+        project: {
+            id: projectId,
+        },
         value,
     }) {
         return (
-            <RuleBuilder
-                rule={value.rule as WrapperRule}
-                setRule={rule => onChange({ ...value, rule })}
-                headerPrefix="Does user match "
+            <EntityIdPicker
+                label="Rule Set"
+                subtitle="Does the user match the conditions of the rule set."
+                get={useCallback(async id => await api.lists.get(projectId, id), [projectId])}
+                search={useCallback(async q => await api.lists.search(projectId, { q, limit: 50 }), [projectId])}
+                value={value.list_id}
+                onChange={list_id => onChange({ ...value, list_id })}
+                required
+                createModalSize="large"
+                renderCreateForm={onCreated => (
+                    <ListCreateForm
+                        isJourneyList={true}
+                        onCreated={onCreated}
+                    />
+                )}
+                onEditLink={list => window.open(`/projects/${projectId}/lists/${list.id}`)}
             />
         )
     },

--- a/apps/ui/src/views/users/RuleBuilder.css
+++ b/apps/ui/src/views/users/RuleBuilder.css
@@ -102,3 +102,11 @@
     font-weight: 500;
     width: 100%;
 }
+
+.rule-form-title {
+    margin: 10px 0 0;
+}
+
+.rule-form-title span {
+    font-weight: 500;
+}

--- a/apps/ui/src/views/users/RuleBuilder.tsx
+++ b/apps/ui/src/views/users/RuleBuilder.tsx
@@ -1,5 +1,6 @@
 import { Combobox } from '@headlessui/react'
-import { Operator, Rule, RuleSuggestions, RuleType, WrapperRule } from '../../types'
+import { Operator, Rule, RuleSuggestions, RuleType, WrapperRule, ControlledInputProps, FieldProps } from '../../types'
+import { FieldPath, FieldValues, useController } from 'react-hook-form'
 import Button from '../../ui/Button'
 import ButtonGroup from '../../ui/ButtonGroup'
 import { SingleSelect } from '../../ui/form/SingleSelect'
@@ -12,6 +13,7 @@ import { useResolver } from '../../hooks'
 import api from '../../api'
 import { highlightSearch, usePopperSelectDropdown } from '../../ui/utils'
 import clsx from 'clsx'
+import { snakeToTitle } from '../../utils'
 
 export const createWrapperRule = (): WrapperRule => ({
     path: '$',
@@ -405,4 +407,34 @@ export default function RuleBuilder({ headerPrefix, rule, setRule }: RuleBuilder
             />
         </RuleEditContext.Provider>
     )
+}
+
+RuleBuilder.Field = function RuleBuilderField<X extends FieldValues, P extends FieldPath<X>>({
+    form,
+    name,
+    label,
+    required,
+    onChange,
+}: Partial<ControlledInputProps<Rule>> & FieldProps<X, P>) {
+
+    const { field } = useController({
+        control: form.control,
+        name,
+        rules: {
+            required,
+        },
+    })
+
+    return <>
+        <div className="rule-form-title">
+            <span>
+                {label ?? snakeToTitle(name)}
+                {required && <span style={{ color: 'red' }}>&nbsp;*</span>}
+            </span>
+        </div>
+        <RuleBuilder rule={field.value} setRule={async (rule) => {
+            await field.onChange?.(rule)
+            onChange?.(rule)
+        }} />
+    </>
 }


### PR DESCRIPTION
Fixes a fundamental problem with gates currently were they are only evaluating a single event which may have nothing to do with the evaluation context. A gate should be able to look at all events in the past. This solution moves to using lists as the core building block of gates so that users will propagate over time.