### PR TITLE
Fixes schema fields not properly setting text inputs to numbers

### DIFF
--- a/apps/ui/src/ui/form/SchemaFields.tsx
+++ b/apps/ui/src/ui/form/SchemaFields.tsx
@@ -52,6 +52,7 @@ export default function SchemaFields({ title, description, parent, form, schema 
                         key={key}
                         form={form}
                         name={`${parent}.${key}`}
+                        type={item.type === 'number' ? 'number' : 'text'}
                         label={title}
                         subtitle={item.description}
                         required={required}


### PR DESCRIPTION
Sets the type of a textfield to number when JSON schema needs it vs a string so that validation properly passes.

Fixes #213