### PR TITLE
Fixes empty locale creation

### DIFF
--- a/apps/ui/src/views/campaign/CampaignDetail.tsx
+++ b/apps/ui/src/views/campaign/CampaignDetail.tsx
@@ -44,7 +44,7 @@ export const createLocale = async ({ locale, data }: LocaleParams, campaign: Cam
         campaign_id: campaign.id,
         type: campaign.channel,
         locale,
-        data: { ...template?.data, ...data },
+        data: template?.data ? { ...template?.data, ...data } : undefined,
     })
 }
 


### PR DESCRIPTION
When creating a new locale for non email campaigns it is failing because of allowing changing editor