### PR TITLE
Allows for recurring sends when a part of a journey

### DIFF
--- a/apps/platform/db/migrations/20230707221741_add_campaign_send_step_id.js
+++ b/apps/platform/db/migrations/20230707221741_add_campaign_send_step_id.js
@@ -1,0 +1,38 @@
+exports.up = async function(knex) {
+    await knex.schema.alterTable('campaign_sends', function(table) {
+        table.integer('user_step_id')
+            .unsigned()
+            .notNullable()
+            .defaultTo(0) // this is 0 so it can be a part of the unique index
+        table.dropForeign('user_id')
+        table.dropForeign('campaign_id')
+        table.dropUnique(['user_id', 'campaign_id'])
+        table.unique(['user_id', 'campaign_id', 'user_step_id'])
+        table.foreign('user_id')
+            .references('id')
+            .inTable('users')
+            .onDelete('CASCADE')
+        table.foreign('campaign_id')
+            .references('id')
+            .inTable('campaigns')
+            .onDelete('CASCADE')
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('campaign_sends', function(table) {
+        table.dropForeign('user_id')
+        table.dropForeign('campaign_id')
+        table.dropUnique(['user_id', 'campaign_id', 'user_step_id'])
+        table.unique(['user_id', 'campaign_id'])
+        table.dropColumn('user_step_id')
+        table.foreign('user_id')
+            .references('id')
+            .inTable('users')
+            .onDelete('CASCADE')
+        table.foreign('campaign_id')
+            .references('id')
+            .inTable('campaigns')
+            .onDelete('CASCADE')
+    })
+}

--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -61,6 +61,7 @@ export class CampaignSend extends Model {
     send_at!: string | Date
     opened_at!: string | Date
     clicks!: number
+    user_step_id?: number
 }
 
 export type CampaignSendParams = Pick<CampaignSend, 'campaign_id' | 'user_id' | 'state' | 'send_at'>

--- a/apps/platform/src/campaigns/CampaignInteractJob.ts
+++ b/apps/platform/src/campaigns/CampaignInteractJob.ts
@@ -6,6 +6,7 @@ import { getCampaignSend, updateCampaignSend } from './CampaignService'
 interface CampaignIteraction {
     user_id: number
     campaign_id: number
+    user_step_id: number
     subscription_id?: number
     type: 'clicked' | 'opened' | 'bounced' | 'complained' | 'failed'
     action?: 'unsubscribe'
@@ -18,8 +19,8 @@ export default class CampaignInteractJob extends Job {
         return new this(data)
     }
 
-    static async handler({ campaign_id, user_id, subscription_id, type, action }: CampaignIteraction) {
-        const send = await getCampaignSend(campaign_id, user_id)
+    static async handler({ campaign_id, user_id, subscription_id, type, action, user_step_id }: CampaignIteraction) {
+        const send = await getCampaignSend(campaign_id, user_id, user_step_id)
         if (!send) return
 
         if (type === 'opened' && !send.opened_at) {

--- a/apps/platform/src/journey/JourneyRepository.ts
+++ b/apps/platform/src/journey/JourneyRepository.ts
@@ -91,7 +91,7 @@ export const getJourneyStepChildren = async (stepId: number) => {
     )
 }
 
-const getAllJourneyStepChildren = async (journeyId: number, db?: Database): Promise<JourneyStepChild[]> => {
+export const getAllJourneyStepChildren = async (journeyId: number, db?: Database): Promise<JourneyStepChild[]> => {
     return await JourneyStepChild.all(
         q => q
             .whereIn('step_id', JourneyStep.query(db).select('id').where('journey_id', journeyId))

--- a/apps/platform/src/journey/JourneyService.ts
+++ b/apps/platform/src/journey/JourneyService.ts
@@ -3,7 +3,6 @@ import { getJourneyEntrance, getJourneyStep, getUserJourneyIds, lastJourneyStep 
 import { JourneyEntrance, JourneyStep, journeyStepTypes } from './JourneyStep'
 import { UserEvent } from '../users/UserEvent'
 import List from '../lists/List'
-import { acquireLock, releaseLock } from '../config/scheduler'
 
 /**
  * Update all journeys that the user is currently in. Admittence to a
@@ -44,46 +43,33 @@ export default class JourneyService {
 
     async run(user: User, event?: UserEvent): Promise<void> {
 
-        const key = `parcelvoy:journey:${this.journeyId}:${user.id}`
+        const processed: number[] = []
 
-        // avoid running multiple times in parallel
-        const locked = await acquireLock({ key })
-        if (!locked) {
-            return
-        }
+        // Loop through all possible next steps until we get an empty next
+        // which signifies that the journey is in a pending state
 
-        try {
+        let nextStep: JourneyStep | undefined | null = await this.nextStep(user)
+        while (nextStep) {
+            if (processed.includes(nextStep.id)) {
+                // Avoid infinite loop in single run
+                break
+            }
+            processed.push(nextStep.id)
+            nextStep = this.parse(nextStep)
 
-            const processed: number[] = []
-
-            // Loop through all possible next steps until we get an empty next
-            // which signifies that the journey is in a pending state
-
-            let nextStep: JourneyStep | undefined | null = await this.nextStep(user)
-            while (nextStep) {
-                if (processed.includes(nextStep.id)) {
-                    // Avoid infinite loop in single run
-                    break
-                }
-                processed.push(nextStep.id)
-                nextStep = this.parse(nextStep)
-
-                // If completed, jump to next otherwise validate condition
-                if (await nextStep.hasCompleted(user)) {
+            // If completed, jump to next otherwise validate condition
+            if (await nextStep.hasCompleted(user)) {
+                nextStep = await nextStep.next(user)
+            } else if (await nextStep.condition(user, event)) {
+                const proceed = await nextStep.complete(user, event)
+                if (proceed) {
                     nextStep = await nextStep.next(user)
-                } else if (await nextStep.condition(user, event)) {
-                    const proceed = await nextStep.complete(user, event)
-                    if (proceed) {
-                        nextStep = await nextStep.next(user)
-                    } else {
-                        nextStep = null
-                    }
                 } else {
                     nextStep = null
                 }
+            } else {
+                nextStep = null
             }
-        } finally {
-            await releaseLock(key)
         }
     }
 

--- a/apps/platform/src/providers/MessageTrigger.ts
+++ b/apps/platform/src/providers/MessageTrigger.ts
@@ -3,4 +3,5 @@ export interface MessageTrigger {
     campaign_id: number
     user_id: number
     event_id?: number
+    user_step_id?: number
 }

--- a/apps/platform/src/providers/email/EmailJob.ts
+++ b/apps/platform/src/providers/email/EmailJob.ts
@@ -25,7 +25,12 @@ export default class EmailJob extends Job {
         // Load email channel so its ready to send
         const channel = await loadEmailChannel(campaign.provider_id, project.id)
         if (!channel) {
-            await updateSendState(campaign, user, 'aborted')
+            await updateSendState({
+                campaign,
+                user,
+                user_step_id: trigger.user_step_id,
+                state: 'aborted',
+            })
             App.main.error.notify(new Error('Unabled to send when there is no channel available.'))
             return
         }
@@ -39,13 +44,22 @@ export default class EmailJob extends Job {
         } catch (error: any) {
 
             // On error, mark as failed and notify just in case
-            await updateSendState(campaign, user, 'failed')
+            await updateSendState({
+                campaign,
+                user,
+                user_step_id: trigger.user_step_id,
+                state: 'failed',
+            })
             App.main.error.notify(error)
             return
         }
 
         // Update send record
-        await updateSendState(campaign, user)
+        await updateSendState({
+            campaign,
+            user,
+            user_step_id: trigger.user_step_id,
+        })
 
         // Create an event on the user about the email
         await createEvent(user, {

--- a/apps/platform/src/providers/push/PushJob.ts
+++ b/apps/platform/src/providers/push/PushJob.ts
@@ -27,7 +27,12 @@ export default class PushJob extends Job {
             // Load email channel so its ready to send
             const channel = await loadPushChannel(campaign.provider_id, project.id)
             if (!channel) {
-                await updateSendState(campaign, user, 'aborted')
+                await updateSendState({
+                    campaign,
+                    user,
+                    user_step_id: trigger.user_step_id,
+                    state: 'aborted',
+                })
                 return
             }
 
@@ -37,7 +42,11 @@ export default class PushJob extends Job {
 
             // Send the push and update the send record
             await channel.send(template, { user, event, context })
-            await updateSendState(campaign, user)
+            await updateSendState({
+                campaign,
+                user,
+                user_step_id: trigger.user_step_id,
+            })
 
             // Create an event on the user about the push
             await createEvent(user, {
@@ -55,7 +64,12 @@ export default class PushJob extends Job {
                 await disableNotifications(user.id, error.invalidTokens)
 
                 // Update send record
-                await updateSendState(campaign, user, 'failed')
+                await updateSendState({
+                    campaign,
+                    user,
+                    user_step_id: trigger.user_step_id,
+                    state: 'failed',
+                })
 
                 // Create an event about the disabling
                 await createEvent(user, {

--- a/apps/platform/src/providers/text/TextJob.ts
+++ b/apps/platform/src/providers/text/TextJob.ts
@@ -25,7 +25,12 @@ export default class TextJob extends Job {
         // Send and render text
         const channel = await loadTextChannel(campaign.provider_id, project.id)
         if (!channel) {
-            await updateSendState(campaign, user, 'aborted')
+            await updateSendState({
+                campaign,
+                user,
+                user_step_id: trigger.user_step_id,
+                state: 'aborted',
+            })
             App.main.error.notify(new Error('Unabled to send when there is no channel available.'))
             return
         }
@@ -37,7 +42,11 @@ export default class TextJob extends Job {
         await channel.send(template, { user, event, context })
 
         // Update send record
-        await updateSendState(campaign, user)
+        await updateSendState({
+            campaign,
+            user,
+            user_step_id: trigger.user_step_id,
+        })
 
         // Create an event on the user about the text
         await createEvent(user, {

--- a/apps/platform/src/providers/webhook/WebhookJob.ts
+++ b/apps/platform/src/providers/webhook/WebhookJob.ts
@@ -23,7 +23,12 @@ export default class WebhookJob extends Job {
         // Send and render webhook
         const channel = await loadWebhookChannel(campaign.provider_id, project.id)
         if (!channel) {
-            await updateSendState(campaign, user, 'aborted')
+            await updateSendState({
+                campaign,
+                user,
+                user_step_id: trigger.user_step_id,
+                state: 'aborted',
+            })
             return
         }
 
@@ -34,7 +39,11 @@ export default class WebhookJob extends Job {
         await channel.send(template, { user, event, context })
 
         // Update send record
-        await updateSendState(campaign, user)
+        await updateSendState({
+            campaign,
+            user,
+            user_step_id: trigger.user_step_id,
+        })
 
         // Create an event on the user about the email
         await createEvent(user, {

--- a/apps/platform/src/render/LinkService.ts
+++ b/apps/platform/src/render/LinkService.ts
@@ -35,6 +35,7 @@ export const paramsToEncodedLink = (params: TrackedLinkParts): string => {
 interface TrackedLinkExport {
     user?: User
     campaign?: Campaign
+    userStepId?: number
     redirect: string
 }
 
@@ -42,9 +43,10 @@ export const encodedLinkToParts = async (link: string | URL): Promise<TrackedLin
     const url = link instanceof URL ? link : new URL(link)
     const userId = decodeHashid(url.searchParams.get('u'))
     const campaignId = decodeHashid(url.searchParams.get('c'))
+    const userStepId = decodeHashid(url.searchParams.get('s'))
     const redirect = decodeURIComponent(url.searchParams.get('r') ?? '')
 
-    const parts: TrackedLinkExport = { redirect }
+    const parts: TrackedLinkExport = { redirect, userStepId }
 
     if (userId) {
         parts.user = await getUser(userId)
@@ -113,7 +115,7 @@ export const trackMessageEvent = async (
     action?: 'unsubscribe',
     context?: any,
 ) => {
-    const { user, campaign } = parts
+    const { user, campaign, userStepId } = parts
     if (!user || !campaign) return
 
     const eventJob = EventPostJob.from({
@@ -137,6 +139,7 @@ export const trackMessageEvent = async (
     const campaignJob = CampaignInteractJob.from({
         campaign_id: campaign.id,
         user_id: user.id,
+        user_step_id: userStepId ?? 0,
         subscription_id: campaign.subscription_id,
         type,
         action,

--- a/apps/platform/src/render/LinkService.ts
+++ b/apps/platform/src/render/LinkService.ts
@@ -11,6 +11,7 @@ import { combineURLs, decodeHashid, encodeHashid } from '../utilities'
 export interface TrackedLinkParams {
     userId: number
     campaignId: number
+    userStepId?: number
 }
 
 interface TrackedLinkParts extends TrackedLinkParams {
@@ -26,6 +27,9 @@ export const paramsToEncodedLink = (params: TrackedLinkParts): string => {
     const url = new URL(baseUrl)
     url.searchParams.set('u', hashUserId)
     url.searchParams.set('c', hashCampaignId)
+    if (params.userStepId) {
+        url.searchParams.set('s', encodeHashid(params.userStepId))
+    }
     if (params.redirect) {
         url.searchParams.set('r', encodeURIComponent(params.redirect))
     }

--- a/apps/platform/src/render/index.ts
+++ b/apps/platform/src/render/index.ts
@@ -55,7 +55,11 @@ interface WrapParams {
     variables: Variables
 }
 export const Wrap = ({ html, preheader, variables: { user, context } }: WrapParams) => {
-    const trackingParams = { userId: user.id, campaignId: context.campaign_id }
+    const trackingParams = {
+        userId: user.id,
+        campaignId: context.campaign_id,
+        userStepId: context.user_step_id,
+    }
 
     // Check if link wrapping is enabled first
     if (App.main.env.tracking.linkWrap) {
@@ -76,6 +80,7 @@ export default (template: string, { user, event, context }: Variables) => {
         unsubscribeEmailUrl: unsubscribeEmailLink({
             userId: user.id,
             campaignId: context?.campaign_id,
+            userStepId: context.user_step_id,
         }),
         preferencesUrl: preferencesLink(user.id),
     })

--- a/apps/platform/src/render/index.ts
+++ b/apps/platform/src/render/index.ts
@@ -16,6 +16,7 @@ export type RenderContext = {
     template_id: number
     campaign_id: number
     subscription_id: number
+    user_step_id?: number
 } & Record<string, unknown>
 
 export interface Variables {


### PR DESCRIPTION
1. added `campaign_sends.user_step_id`. this is now a part of its unique index so that we can send once per user step (including when the step is visited multiple times). this is not an actual FK because we need to allow `0` as a value for email blasts, since mysql doesn't work w/ `null` in the unique key.
2. action step type checks to see if the campaign has completed for that `campaign_id` + `user_id` + `user_step_id` combo before continuing. the reprocessing is triggered by the user event that is triggered by the send.
3. various other updates were needed to account for the new unique index on sends