### PR TITLE
Prevents campaign from regenerating list

### DIFF
--- a/apps/platform/src/campaigns/CampaignGenerateListJob.ts
+++ b/apps/platform/src/campaigns/CampaignGenerateListJob.ts
@@ -11,6 +11,7 @@ export default class CampaignGenerateListJob extends Job {
 
     static async handler({ id, project_id }: CampaignJobParams) {
         const campaign = await getCampaign(id, project_id) as SentCampaign
+        if (campaign.state === 'aborted' || campaign.state === 'draft') return
         await generateSendList(campaign)
     }
 }

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -255,7 +255,6 @@ export const generateSendList = async (campaign: SentCampaign) => {
 
     const query = recipientQuery(campaign)
     await chunk<CampaignSendParams>(query, 100, async (items) => {
-        if (chunk.length <= 0) return
         await CampaignSend.query()
             .insert(items)
             .onConflict(['user_id', 'list_id'])

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -46,7 +46,10 @@ export const allCampaigns = async (projectId: number): Promise<Campaign[]> => {
 }
 
 export const getCampaign = async (id: number, projectId: number): Promise<Campaign | undefined> => {
-    const campaign = await Campaign.find(id, qb => qb.where('project_id', projectId))
+    const campaign = await Campaign.find(id,
+        qb => qb.where('project_id', projectId)
+            .whereNull('deleted_at'),
+    )
 
     if (campaign) {
         campaign.templates = await allTemplates(projectId, campaign.id)

--- a/apps/platform/src/utilities/index.ts
+++ b/apps/platform/src/utilities/index.ts
@@ -189,13 +189,13 @@ export const chunk = async <T>(
         for await (const result of stream) {
             chunk.push(modifier(result))
             i++
-            if (i % size === 0) {
+            if (i % size === 0 && chunk.length > 0) {
                 await callback(chunk)
                 chunk = []
             }
         }
     })
         .then(async function() {
-            await callback(chunk)
+            if (chunk.length > 0) await callback(chunk)
         })
 }


### PR DESCRIPTION
If a queue gets overloaded a campaign could continue regenerating and changing its state away from aborted, etc