### PR TITLE
Fixes rule matching for certain cases like 'is set'

### DIFF
--- a/apps/platform/src/rules/RuleHelpers.ts
+++ b/apps/platform/src/rules/RuleHelpers.ts
@@ -67,13 +67,17 @@ export const whereQuery = <T extends AnyJson | Date>({ builder, isJson, column, 
 
 export const whereQueryNullable = ({ builder, isJson, column, path, wrapper }: QueryRuleParams, isNull: boolean): Database.QueryBuilder<any> => {
     if (wrapper === 'or') {
-        isJson
+        return isJson
             ? builder.orWhereJsonPath(column, path, isNull ? '=' : '!=', null)
-            : builder.orWhere(column, isNull ? 'IS NULL' : 'IS NOT NULL')
+            : isNull
+                ? builder.orWhereNull(column)
+                : builder.orWhereNotNull(column)
     }
     return isJson
         ? builder.whereJsonPath(column, path, isNull ? '=' : '!=', null)
-        : builder.where(column, isNull ? 'IS NULL' : 'IS NOT NULL')
+        : isNull
+            ? builder.whereNull(column)
+            : builder.whereNotNull(column)
 }
 
 interface QueryRuleParams {

--- a/apps/ui/src/views/users/RuleBuilder.tsx
+++ b/apps/ui/src/views/users/RuleBuilder.tsx
@@ -120,8 +120,8 @@ function RuleEdit({
     } = usePopperSelectDropdown()
 
     const { suggestions } = useContext(RuleEditContext)
-
     const { path } = rule
+    const hasValue = rule?.operator && !['is set', 'is not set', 'empty'].includes(rule?.operator)
 
     const pathSuggestions = useMemo<string[]>(() => {
 
@@ -374,7 +374,7 @@ function RuleEdit({
                     size="small"
                     toValue={x => x.key}
                 />
-                <TextInput
+                { hasValue && <TextInput
                     size="small"
                     type="text"
                     name="value"
@@ -382,7 +382,7 @@ function RuleEdit({
                     hideLabel={true}
                     value={rule?.value?.toString()}
                     onChange={value => setRule({ ...rule, value })}
-                />
+                />}
                 {controls}
             </ButtonGroup>
         </div>


### PR DESCRIPTION
The SQL generated for operators like `is set` was not correct and was generating fewer results than would be expected. This also updates the UI of the rule builder not now show the value field when one cant be set