### PR TITLE
optimize journey delay job by filtering unmet delay requirements at t…

### DIFF
--- a/apps/platform/db/migrations/20230813184853_add_journey_user_step_delay_until.js
+++ b/apps/platform/db/migrations/20230813184853_add_journey_user_step_delay_until.js
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const dateFns = require('date-fns')
+const dateFnsTz = require('date-fns-tz')
+
+exports.up = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.timestamp('delay_until')
+    })
+
+    const delayedUserSteps = knex
+        .with(
+            'latest_journey_steps',
+            knex.raw(`
+                select
+                    us.id as 'id',
+                    us.created_at as 'created_at',
+                    us.type as 'type',
+                    s.data as 'data',
+                    coalesce(u.timezone, p.timezone) as 'tz',
+                    row_number() over (partition by us.user_id, us.journey_id order by us.id desc) as 'rn'
+                from journey_user_step us
+                    left join journey_steps s on us.step_id = s.id
+                    left join users u on us.user_id = u.id
+                    left join projects p on u.project_id = p.id
+            `),
+        )
+        .select('*')
+        .from('latest_journey_steps')
+        .where({
+            rn: 1,
+            type: 'delay',
+        })
+        .stream()
+
+    for await (const { id, created_at, data, tz } of delayedUserSteps) {
+
+        let delay_until = dateFns.parse(created_at)
+
+        if (data?.format === 'duration') {
+
+            delay_until = dateFns.addMinutes(delay_until, ((data?.days ?? 0) * 1440) + ((data?.hours ?? 0) * 60) + ((data?.minutes ?? 0)))
+
+        } else if (data?.format === 'time' && data.time) {
+
+            if (tz) delay_until = dateFnsTz.utcToZonedTime(delay_until, tz)
+            delay_until = dateFns.parse(data.time.trim(), 'HH:mm', delay_until)
+            if (tz) delay_until = dateFnsTz.zonedTimeToUtc(delay_until, tz)
+
+        } else if (data?.format === 'date' && data.date) {
+
+            delay_until = new Date(data.date)
+            if (tz) delay_until = dateFnsTz.zonedTimeToUtc(delay_until, tz)
+
+        }
+
+        await knex('journey_user_step').update({ delay_until }).where('id', id)
+    }
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.dropColumn('delay_until')
+    })
+}

--- a/apps/platform/src/journey/JourneyDelayJob.ts
+++ b/apps/platform/src/journey/JourneyDelayJob.ts
@@ -1,6 +1,4 @@
 import { Job } from '../queue'
-import { JourneyUserStep } from './JourneyStep'
-import { raw } from '../core/Model'
 import JourneyProcessJob from './JourneyProcessJob'
 import App from '../app'
 
@@ -12,30 +10,34 @@ export default class JourneyDelayJob extends Job {
     static $name = 'journey_delay_job'
 
     static async handler() {
-        await JourneyUserStep.query()
+
+        await App.main.db
             .with(
                 'latest_journey_steps',
-                raw('SELECT j.*, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY id DESC) AS rn FROM journey_user_step AS j'),
+                App.main.db.raw('select j.*, row_number() over (partition by user_id, journey_id order by id desc) as rn from journey_user_step as j'),
             )
-            .select('step_id', 'user_id', 'type', 'journey_id', 'project_id')
             .from('latest_journey_steps')
             .leftJoin('journeys', 'journeys.id', '=', 'latest_journey_steps.journey_id')
-            .where({
-                rn: 1,
-                type: 'delay',
-            })
-            .stream(async function(stream) {
-                for await (const chunk of stream) {
+            .where('rn', 1)
+            .where('type', 'delay')
+            .where('delay_until', '<=', Date.now())
+            .stream(async stream => {
 
-                    // TODO: Room for improvement here by not reprocessing
-                    // the entire journey but instead just this step (could
-                    // have some downsides through)
-                    App.main.queue.enqueue(
-                        JourneyProcessJob.from({
-                            user_id: chunk.user_id,
-                            journey_id: chunk.journey_id,
-                        }),
-                    )
+                let chunk: Job[] = []
+
+                for await (const { journey_id, user_id } of stream) {
+                    chunk.push(JourneyProcessJob.from({
+                        user_id,
+                        journey_id,
+                    }))
+                    if (chunk.length >= App.main.queue.batchSize) {
+                        await App.main.queue.enqueueBatch(chunk)
+                        chunk = []
+                    }
+                }
+
+                if (chunk.length) {
+                    await App.main.queue.enqueueBatch(chunk)
                 }
             })
     }


### PR DESCRIPTION
…he db level

- adds `journey_user_step.delay_until` timestamp
- updates `JourneyDelayJob` to only look up user steps that are actually ready to move on
- fixes partitioning issue