### PR TITLE
Improves how campaign sends are added to the queue

### DIFF
--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -203,8 +203,12 @@ export const sendCampaignJob = ({ campaign, user, event, send_id, user_step_id }
         push: PushJob.from(body),
         webhook: WebhookJob.from(body),
     }
+    const job = channels[campaign.channel]
+    if (send_id) {
+        job.jobId(`sid${send_id}`)
+    }
 
-    return channels[campaign.channel]
+    return job
 }
 
 export const sendCampaign = async (data: SendCampaign): Promise<void> => {

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -99,7 +99,7 @@ export const prepareSend = async <T>(
 
         // Schedule the resend for a jittered number of seconds later
         const delay = 1000 + randomInt(0, 5000)
-        await requeueSend(raw, delay)
+        await App.main.queue.delay(raw, delay)
         return false
     }
 
@@ -124,9 +124,4 @@ export const throttleSend = async (channel: Channel, points = 1): Promise<RateLi
             points,
         },
     )
-}
-
-export const requeueSend = async (job: EncodedJob, delay: number): Promise<void> => {
-    job.options.delay = delay
-    return await App.main.queue.enqueue(job)
 }

--- a/apps/platform/src/queue/Job.ts
+++ b/apps/platform/src/queue/Job.ts
@@ -1,14 +1,16 @@
 import App from '../app'
 
 interface JobOptions {
-    delay?: number
+    delay?: number // Milliseconds
     attempts?: number
+    jobId?: string
 }
 
 export interface EncodedJob {
     data: any
     options: JobOptions
     name: string
+    token?: string
 }
 
 export class JobError extends Error {
@@ -53,8 +55,13 @@ export default class Job implements EncodedJob {
         this.data = data
     }
 
-    delay(seconds: number) {
-        this.options.delay = seconds
+    delay(milliseconds: number) {
+        this.options.delay = milliseconds
+        return this
+    }
+
+    jobId(id: string) {
+        this.options.jobId = id
         return this
     }
 

--- a/apps/platform/src/queue/MemoryQueueProvider.ts
+++ b/apps/platform/src/queue/MemoryQueueProvider.ts
@@ -25,6 +25,11 @@ export default class MemoryQueueProvider implements QueueProvider {
         this.backlog.push(...jobs)
     }
 
+    async delay(job: Job, milliseconds: number): Promise<void> {
+        job.options.delay = milliseconds
+        await this.enqueue(job)
+    }
+
     start(): void {
         if (process.env.NODE_ENV === 'test') return
         if (this.loop) return

--- a/apps/platform/src/queue/Queue.ts
+++ b/apps/platform/src/queue/Queue.ts
@@ -58,6 +58,10 @@ export default class Queue {
         await App.main.stats.increment(jobs.map(job => job.name))
     }
 
+    async delay(job: EncodedJob, milliseconds: number) {
+        await this.provider.delay(job, milliseconds)
+    }
+
     get batchSize() {
         return this.provider.batchSize
     }

--- a/apps/platform/src/queue/QueueProvider.ts
+++ b/apps/platform/src/queue/QueueProvider.ts
@@ -26,6 +26,7 @@ export default interface QueueProvider {
     batchSize: number
     enqueue(job: EncodedJob): Promise<void>
     enqueueBatch(jobs: EncodedJob[]): Promise<void>
+    delay(job: EncodedJob, milliseconds: number): Promise<void>
     start(): void
     close(): void
     metrics?(period: MetricPeriod): Promise<QueueMetric>

--- a/apps/platform/src/queue/SQSQueueProvider.ts
+++ b/apps/platform/src/queue/SQSQueueProvider.ts
@@ -64,6 +64,11 @@ export default class SQSQueueProvider implements QueueProvider {
         }
     }
 
+    async delay(job: Job, milliseconds: number): Promise<void> {
+        job.options.delay = milliseconds
+        await this.enqueue(job)
+    }
+
     start(): void {
         const app = Consumer.create({
             queueUrl: this.config.queueUrl,


### PR DESCRIPTION
Large throttled sends have a tendency to overload the queue to the point where it reaches unstable levels.

Causes:
- Items don't have their status updated until the queue updates it
- If an item is in the queue for longer than one minute (because of a large backlog), it'll be added (as a duplicate) again because the job to add sends to the queue re-runs
- If any of those added items then is throttled, it will duplicate itself keeping the queue at its inflated size for longer than necessary

This PR prevents duplicate jobs by manually setting the ID and also improves the delay process for jobs running in Redis queues.