### PR TITLE
Improves lookups for schema changes by adding indexes

### DIFF
--- a/apps/platform/db/migrations/20230827174518_add_user_events_date_index.js
+++ b/apps/platform/db/migrations/20230827174518_add_user_events_date_index.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+    await knex.schema.table('user_events', function(table) {
+        table.index('created_at')
+    })
+    await knex.schema.table('users', function(table) {
+        table.index('updated_at')
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('user_events', function(table) {
+        table.dropIndex('created_at')
+    })
+    await knex.schema.table('users', function(table) {
+        table.dropIndex('updated_at')
+    })
+}

--- a/apps/platform/src/schema/UserSchemaService.ts
+++ b/apps/platform/src/schema/UserSchemaService.ts
@@ -82,7 +82,7 @@ export async function syncUserDataPaths({
             .where('project_id', project_id)
             .select('name', 'data')
         if (updatedAfter) {
-            eventQuery.where('updated_at', '>=', updatedAfter)
+            eventQuery.where('created_at', '>=', updatedAfter)
         }
 
         await eventQuery.stream(async function(stream) {


### PR DESCRIPTION
- Adds `created_at` index to `user_events`
- Adds `updated_at` index to `users`

Should overall improve performance of all schema lookups and improve general performance of other queries as a result