### PR TITLE
break journey delay job up, lock for journey service processing

### DIFF
--- a/apps/platform/src/config/scheduler.ts
+++ b/apps/platform/src/config/scheduler.ts
@@ -15,7 +15,7 @@ export default (app: App) => {
     scheduler.schedule({
         rule: '* * * * *',
         callback: () => {
-            app.queue.enqueue(JourneyDelayJob.from())
+            JourneyDelayJob.enqueueActive(app)
             app.queue.enqueue(CampaignTriggerJob.from())
             app.queue.enqueue(CampaignStateJob.from())
         },

--- a/apps/platform/src/journey/JourneyDelayJob.ts
+++ b/apps/platform/src/journey/JourneyDelayJob.ts
@@ -1,8 +1,13 @@
 import { Job } from '../queue'
-import JourneyProcessJob from './JourneyProcessJob'
 import App from '../app'
 import { chunk } from '../utilities'
 import { JourneyUserStep } from './JourneyStep'
+import Journey from './Journey'
+import JourneyProcessJob from './JourneyProcessJob'
+
+interface JourneyDelayJobParams {
+    journey_id: number
+}
 
 /**
  * A job to be run on a schedule to queue up all journeys that need
@@ -11,21 +16,41 @@ import { JourneyUserStep } from './JourneyStep'
 export default class JourneyDelayJob extends Job {
     static $name = 'journey_delay_job'
 
-    static async handler() {
+    static async enqueueActive(app: App) {
+        const query = Journey.query(app.db).select('id').where('published', true)
+        await chunk<{ id: number }>(query, app.queue.batchSize, async journeys => {
+            app.queue.enqueueBatch(journeys.map(({ id }) => JourneyDelayJob.from(id)))
+        })
+    }
+
+    static from(journey_id: number) {
+        return new JourneyDelayJob({ journey_id })
+    }
+
+    static async handler({ journey_id }: JourneyDelayJobParams) {
+
+        if (!journey_id) return
 
         const { db, queue } = App.main
 
-        const query = JourneyUserStep.query(db)
-            .distinct(db.raw('ifnull(journey_user_step.entrance_id, journey_user_step.id) as entrance_id'))
-            .leftJoin('journeys', 'journeys.id', '=', 'journey_user_step.journey_id')
-            .where('journeys.published', true) // ignore inactive journeys
-            .where('journey_user_step.type', 'delay') // only include steps where the current type/status is 'delay'
-            .where('journey_user_step.delay_until', '<=', new Date())
+        const count = await JourneyUserStep.update(
+            q => q
+                .where('journey_id', journey_id)
+                .where('type', 'delay') // only include steps where the current type/status is 'delay'
+                .where('delay_until', '<=', new Date()),
+            { type: 'pending' },
+        )
 
-        await chunk<{ entrance_id: number }>(query, queue.batchSize, async items => {
-            await queue.enqueueBatch(items.map(({ entrance_id }) => {
-                return JourneyProcessJob.from({ entrance_id })
-            }))
-        })
+        if (count) {
+            // maybe this should have a lock?
+            const query = JourneyUserStep.query(db)
+                .select('id')
+                .where('journey_id', journey_id)
+                .where('type', 'pending')
+
+            await chunk<{ id: number }>(query, queue.batchSize, async items => {
+                await queue.enqueueBatch(items.map(({ id }) => JourneyProcessJob.from({ entrance_id: id })))
+            })
+        }
     }
 }


### PR DESCRIPTION
- separate `JourneyDelayJob` for each journey hopefully avoid a giant journey slowing down others, make more horizontally scalable
- lock per entrance on journey processing
- only update user step if something has actually changed