### PR TITLE
Fixes rule evaluation and list errors

### DIFF
--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -302,7 +302,8 @@ export const updateUsersLists = async (user: User, results: RuleResults, event?:
 const listsForRule = async (ruleUuids: string[], projectId: number): Promise<DynamicList[]> => {
     return await List.all(
         qb => qb.leftJoin('rules', 'rules.id', 'lists.rule_id')
-            .where('project_id', projectId)
+            .where('lists.project_id', projectId)
+            .where('rules.project_id', projectId)
             .where('lists.type', 'dynamic')
             .whereNull('deleted_at')
             .whereIn('rules.uuid', ruleUuids),

--- a/apps/platform/src/rules/RuleService.ts
+++ b/apps/platform/src/rules/RuleService.ts
@@ -134,11 +134,14 @@ const checkEventRule = async (
                     .where('user_id', user.id),
                 { result: true },
             )
-            : await RuleEvaluation.insert({
-                rule_id: node.id,
-                user_id: user.id,
-                result: true,
-            })
+            : await RuleEvaluation.query()
+                .insert({
+                    rule_id: node.id,
+                    user_id: user.id,
+                    result: true,
+                })
+                .onConflict(['user_id', 'rule_id'])
+                .merge(['result'])
         return await checkRootRule(node.root_uuid!, user)
     }
     return false


### PR DESCRIPTION
- Fixes `Column 'project_id' in where clause is ambiguous` error
- Fixes rule evaluations occasionally having duplicates when processed in quick succession or in certain rules