### PR TITLE
Minor fixes to org creation

### DIFF
--- a/apps/platform/src/organizations/OrganizationService.ts
+++ b/apps/platform/src/organizations/OrganizationService.ts
@@ -1,6 +1,6 @@
 import Admin from '../auth/Admin'
 import Provider from '../providers/Provider'
-import { encodeHashid } from '../utilities'
+import { encodeHashid, uuid } from '../utilities'
 import Organization from './Organization'
 
 export const getOrganization = async (id: number) => {
@@ -27,10 +27,18 @@ export const getDefaultOrganization = async () => {
 }
 
 export const createOrganization = async (domain?: string): Promise<Organization> => {
-    const username = domain?.split('.').shift()
-    const org = await Organization.insertAndFetch({
-        username,
-    })
+    let username = domain?.split('.').shift()
+    let org: Organization | undefined
+    try {
+        org = await Organization.insertAndFetch({
+            username,
+        })
+    } catch {
+        username = undefined
+        org = await Organization.insertAndFetch({
+            username: uuid(),
+        })
+    }
 
     // If for some reason the domain format is odd, generate
     // a random username from the org id

--- a/apps/ui/src/views/organization/Admins.tsx
+++ b/apps/ui/src/views/organization/Admins.tsx
@@ -1,13 +1,18 @@
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 import PageContent from '../../ui/PageContent'
 import { SearchTable, useSearchTableQueryState } from '../../ui/SearchTable'
 import api from '../../api'
+import { Alert } from '../../ui'
+import { OrganizationContext } from '../../contexts'
 
 export default function Admins() {
     const state = useSearchTableQueryState(useCallback(async params => await api.admins.search(params), []))
+    const [organization] = useContext(OrganizationContext)
+    const url = `${window.location.protocol}//${organization.username}.${window.location.hostname}:${window.location.port}`
     return (
         <>
             <PageContent title="Admins">
+                <Alert title="Invite Link">To be joined to your organization, send users an invite from a project or have them register using the following link: <br/><strong>{url}</strong></Alert>
                 <SearchTable
                     {...state}
                     columns={[


### PR DESCRIPTION
Prevents username overlap from happening at creation time if someone has picked one that exists already