### PR TITLE
Fixes chunk method not properly awaiting

### DIFF
--- a/apps/platform/src/utilities/index.ts
+++ b/apps/platform/src/utilities/index.ts
@@ -217,7 +217,7 @@ export const chunk = async <T>(
     const chunker = new Chunker(callback, size)
     await query.stream(async function(stream) {
         for await (const result of stream) {
-            chunker.add(modifier(result))
+            await chunker.add(modifier(result))
         }
     })
     await chunker.flush()


### PR DESCRIPTION
Fixes chunk method not properly awaiting which was causing jobs that use the chunking method to frequently timeout and stall.