### PR TITLE
Adds locks to long running campaign processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - 🛣 **Journeys** Build complex journeys with our drag-and-drop builder to schedule, trigger and segment users.
 - 👥 **Segmentation** Create dynamic lists to target users matching any event or user based criteria in real time.
 - 📣 **Campaigns** Build campaigns that target specific lists of users and go out at pre-defined times.
-- 🔗 **Integrations** Connect Parcelvoy in to your applications using out easy to use SDKs and APIs.
+- 🔗 **Integrations** Connect Parcelvoy to your applications using our easy to use SDKs and APIs.
 - 🔒 **Secure** SSO (SAML/OpenID) is provided out of the box, no extra bolts or add-ons.
 - 📦 **Open Source** Easy to setup and get running in your own cloud.
 

--- a/apps/platform/src/journey/ScheduledEntranceJob.ts
+++ b/apps/platform/src/journey/ScheduledEntranceJob.ts
@@ -12,6 +12,8 @@ interface ScheduledEntranceTrigger {
 
 export default class ScheduledEntranceJob extends Job {
 
+    static $name = 'scheduled_entrance_job'
+
     static from(params: ScheduledEntranceTrigger) {
         return new ScheduledEntranceJob(params)
     }

--- a/apps/platform/src/journey/ScheduledEntranceOrchestratorJob.ts
+++ b/apps/platform/src/journey/ScheduledEntranceOrchestratorJob.ts
@@ -5,6 +5,8 @@ import ScheduledEntranceJob from './ScheduledEntranceJob'
 
 export default class ScheduledEntranceOrchestratorJob extends Job {
 
+    static $name = 'scheduled_entrance_orchestration_job'
+
     static async handler() {
 
         // look up all scheduler entrances
@@ -19,7 +21,6 @@ export default class ScheduledEntranceOrchestratorJob extends Job {
         if (!entrances.length) return
 
         const jobs: Job[] = []
-
         for (const entrance of entrances) {
 
             await JourneyStep.update(q => q.where('id', entrance.id), {


### PR DESCRIPTION
Long running processes were overlapping if they took longer to processes than how often they are scheduled. This PR adds a lock to ensure each job is only running once