### PR TITLE
Adds a draft/publish state for lists

### DIFF
--- a/apps/platform/src/lists/List.ts
+++ b/apps/platform/src/lists/List.ts
@@ -1,7 +1,7 @@
 import Model from '../core/Model'
 import { RuleTree } from '../rules/Rule'
 
-export type ListState = 'ready' | 'loading'
+export type ListState = 'draft' | 'ready' | 'loading'
 type ListType = 'static' | 'dynamic'
 
 export default class List extends Model {
@@ -30,5 +30,5 @@ export class UserList extends Model {
     static tableName = 'user_list'
 }
 
-export type ListUpdateParams = Pick<List, 'name' | 'tags'> & { rule?: RuleTree }
+export type ListUpdateParams = Pick<List, 'name' | 'tags'> & { rule?: RuleTree, published?: boolean }
 export type ListCreateParams = ListUpdateParams & Pick<List, 'type' | 'is_visible'> & { rule?: RuleTree }

--- a/apps/platform/src/lists/ListController.ts
+++ b/apps/platform/src/lists/ListController.ts
@@ -154,12 +154,16 @@ const listUpdateParams: JSONSchemaType<ListUpdateParams> = {
             },
             nullable: true,
         },
+        published: {
+            type: 'boolean',
+            nullable: true,
+        },
     },
     additionalProperties: false,
 }
 router.patch('/:listId', async ctx => {
     const payload = validate(listUpdateParams, ctx.request.body)
-    ctx.body = await updateList(ctx.state.list!.id, payload)
+    ctx.body = await updateList(ctx.state.list!, payload)
 })
 
 router.delete('/:listId', async ctx => {

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -309,7 +309,7 @@ export const updateUsersLists = async (user: User, results: RuleResults, event?:
     }
 }
 
-const listsForRule = async (ruleUuids: string[], projectId: number): Promise<DynamicList[]> => {
+export const listsForRule = async (ruleUuids: string[], projectId: number): Promise<DynamicList[]> => {
     return await List.all(
         qb => qb.leftJoin('rules', 'rules.id', 'lists.rule_id')
             .where('lists.project_id', projectId)

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -84,7 +84,7 @@ export const createList = async (projectId: number, { tags, name, type, rule }: 
     const list = await List.insertAndFetch({
         name,
         type,
-        state: 'ready',
+        state: type === 'dynamic' ? 'draft' : 'ready',
         users_count: 0,
         project_id: projectId,
     })
@@ -118,8 +118,11 @@ export const createList = async (projectId: number, { tags, name, type, rule }: 
     return list
 }
 
-export const updateList = async (id: number, { tags, rule, ...params }: ListUpdateParams): Promise<List | undefined> => {
-    const list = await List.updateAndFetch(id, params)
+export const updateList = async (list: List, { tags, rule, published, ...params }: ListUpdateParams): Promise<List | undefined> => {
+    list = await List.updateAndFetch(list.id, {
+        ...params,
+        state: list.state === 'draft' ? published ? 'ready' : 'draft' : list.state,
+    })
 
     if (tags) {
         await setTags({
@@ -312,6 +315,7 @@ const listsForRule = async (ruleUuids: string[], projectId: number): Promise<Dyn
             .where('lists.project_id', projectId)
             .where('rules.project_id', projectId)
             .where('lists.type', 'dynamic')
+            .whereNot('lists.state', 'draft')
             .whereNull('deleted_at')
             .whereIn('rules.uuid', ruleUuids),
     ) as DynamicList[]

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -211,7 +211,7 @@ export interface UserEvent {
     created_at: string
 }
 
-export type ListState = 'ready' | 'loading'
+export type ListState = 'draft' | 'ready' | 'loading'
 type ListType = 'static' | 'dynamic'
 
 export type List = {
@@ -237,7 +237,7 @@ export type List = {
 export type DynamicList = List & { type: 'dynamic' }
 
 export type ListCreateParams = Pick<List, 'name' | 'rule' | 'type' | 'tags' | 'is_visible'>
-export type ListUpdateParams = Pick<List, 'name' | 'rule' | 'tags'>
+export type ListUpdateParams = Pick<List, 'name' | 'rule' | 'tags'> & { published?: boolean }
 
 export interface Journey {
     id: number

--- a/apps/ui/src/views/users/ListCreateForm.tsx
+++ b/apps/ui/src/views/users/ListCreateForm.tsx
@@ -6,14 +6,13 @@ import FormWrapper from '../../ui/form/FormWrapper'
 import RadioInput from '../../ui/form/RadioInput'
 import TextInput from '../../ui/form/TextInput'
 import { TagPicker } from '../settings/TagPicker'
-import RuleBuilder, { createWrapperRule } from './RuleBuilder'
+import { createWrapperRule } from './RuleBuilder'
 
 interface ListCreateFormProps {
     onCreated?: (list: List) => void
-    isJourneyList?: boolean
 }
 
-export function ListCreateForm({ onCreated, isJourneyList = false }: ListCreateFormProps) {
+export function ListCreateForm({ onCreated }: ListCreateFormProps) {
     const [project] = useContext(ProjectContext)
     const defaults: Partial<ListCreateParams> = {
         type: 'dynamic',
@@ -44,26 +43,19 @@ export function ListCreateForm({ onCreated, isJourneyList = false }: ListCreateF
                         label="List Name"
                         required
                     />
-                    {!isJourneyList && <>
-                        <RadioInput.Field
-                            form={form}
-                            name="type"
-                            label="Type"
-                            options={[
-                                { key: 'dynamic', label: 'Dynamic' },
-                                { key: 'static', label: 'Static' },
-                            ]}
-                        />
-                        <TagPicker.Field
-                            form={form}
-                            name="tags"
-                        />
-                    </>}
-                    {isJourneyList && <RuleBuilder.Field
+                    <RadioInput.Field
                         form={form}
-                        name="rule"
-                        required
-                    />}
+                        name="type"
+                        label="Type"
+                        options={[
+                            { key: 'dynamic', label: 'Dynamic' },
+                            { key: 'static', label: 'Static' },
+                        ]}
+                    />
+                    <TagPicker.Field
+                        form={form}
+                        name="tags"
+                    />
                 </>
             )}
         </FormWrapper>

--- a/apps/ui/src/views/users/ListDetail.tsx
+++ b/apps/ui/src/views/users/ListDetail.tsx
@@ -16,7 +16,7 @@ import { snakeToTitle } from '../../utils'
 import UploadField from '../../ui/form/UploadField'
 import { SearchTable, useSearchTableState } from '../../ui/SearchTable'
 import { useRoute } from '../router'
-import { EditIcon, UploadIcon } from '../../ui/icons'
+import { EditIcon, SendIcon, UploadIcon } from '../../ui/icons'
 import { TagPicker } from '../settings/TagPicker'
 
 const RuleSection = ({ list, onRuleSave }: { list: DynamicList, onRuleSave: (rule: Rule) => void }) => {
@@ -39,8 +39,8 @@ export default function ListDetail() {
     const state = useSearchTableState(useCallback(async params => await api.lists.users(project.id, list.id, params), [list, project]))
     const route = useRoute()
 
-    const saveList = async ({ name, rule }: ListUpdateParams) => {
-        const value = await api.lists.update(project.id, list.id, { name, rule })
+    const saveList = async ({ name, rule, published }: ListUpdateParams) => {
+        const value = await api.lists.update(project.id, list.id, { name, rule, published })
         setIsEditListOpen(false)
         setIsDialogOpen(true)
         setList(value)
@@ -64,6 +64,9 @@ export default function ListDetail() {
             }
             actions={
                 <>
+                    {list.state === 'draft' && <Button
+                        icon={<SendIcon />}
+                        onClick={async () => await saveList({ name: list.name, published: true })}>Publish</Button>}
                     {list.type === 'static' && <Button
                         variant="secondary"
                         icon={<UploadIcon />}
@@ -102,7 +105,7 @@ export default function ListDetail() {
                 onClose={() => setIsEditListOpen(false)}
                 title="Edit List">
                 <FormWrapper<Omit<ListUpdateParams, 'rule'>>
-                    onSubmit={async ({ name }) => await saveList({ name })}
+                    onSubmit={async ({ name, published }) => await saveList({ name, published })}
                     submitLabel="Save"
                     defaultValues={{ name: list.name }}
                 >

--- a/apps/ui/src/views/users/ListTable.tsx
+++ b/apps/ui/src/views/users/ListTable.tsx
@@ -1,7 +1,7 @@
 import { Key } from 'react'
 import { List, ListState, SearchParams, SearchResult } from '../../types'
 import { SearchTable, useSearchTableState } from '../../ui/SearchTable'
-import Tag from '../../ui/Tag'
+import Tag, { TagVariant } from '../../ui/Tag'
 import { snakeToTitle } from '../../utils'
 import { useRoute } from '../router'
 import Menu, { MenuItem } from '../../ui/Menu'
@@ -17,8 +17,14 @@ interface ListTableParams {
 }
 
 export const ListTag = ({ state }: { state: ListState }) => {
+    const variant: Record<ListState, TagVariant> = {
+        draft: 'plain',
+        loading: 'info',
+        ready: 'success',
+    }
+
     return (
-        <Tag variant={state === 'ready' ? 'success' : 'info'}>
+        <Tag variant={variant[state]}>
             {snakeToTitle(state)}
         </Tag>
     )


### PR DESCRIPTION
Dynamic lists currently begin to populate immediately after creation which can be problematic since a list in its creation state wont have any rules yet. This adds a draft state to lists which they are in by default. Client events wont check the list when evaluating so no users should join the list until it goes into a published state.