### PR TITLE
Prevent list stats during list generation

### DIFF
--- a/apps/platform/src/lists/ProcessListsJob.ts
+++ b/apps/platform/src/lists/ProcessListsJob.ts
@@ -7,7 +7,7 @@ export default class ProcessListsJob extends Job {
 
     static async handler() {
 
-        const lists = await List.all()
+        const lists = await List.all(qb => qb.whereNot('state', 'loading'))
         for (const list of lists) {
             await ListStatsJob.from(list.id, list.project_id).queue()
         }

--- a/apps/ui/src/views/users/ListDetail.tsx
+++ b/apps/ui/src/views/users/ListDetail.tsx
@@ -59,7 +59,9 @@ export default function ListDetail() {
                 <InfoTable rows={{
                     state: <ListTag state={list.state} />,
                     type: snakeToTitle(list.type),
-                    users_count: list.users_count?.toLocaleString(),
+                    users_count: list.state === 'loading'
+                        ? <>&#8211;</>
+                        : list.users_count?.toLocaleString(),
                 }} direction="horizontal" />
             }
             actions={


### PR DESCRIPTION
Running list stats can cause issues while records are still being imported. Only calculate statistics for lists that have finished initial generation.

Also hides count while import is running.