### PR TITLE
Allows for using alternate S3 providers

### DIFF
--- a/apps/platform/src/config/env.ts
+++ b/apps/platform/src/config/env.ts
@@ -92,8 +92,10 @@ export default (type?: EnvType): Env => {
         storage: driver<StorageConfig>(process.env.STORAGE_DRIVER ?? 'local', {
             s3: () => ({
                 baseUrl: process.env.STORAGE_BASE_URL,
-                bucket: process.env.AWS_S3_BUCKET!,
-                region: process.env.AWS_REGION!,
+                bucket: process.env.STORAGE_S3_BUCKET ?? process.env.AWS_S3_BUCKET!,
+                region: process.env.AWS_REGION ?? 'us-east-1',
+                endpoint: process.env.STORAGE_S3_ENDPOINT,
+                forcePathStyle: process.env.STORAGE_S3_FORCE_PATH_STYLE !== 'false',
                 credentials: {
                     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
                     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,

--- a/apps/platform/src/storage/ImageController.ts
+++ b/apps/platform/src/storage/ImageController.ts
@@ -26,7 +26,7 @@ const uploadMetadata: JSONSchemaType<FileMetadata> = {
         },
         mimeType: {
             type: 'string',
-            enum: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'],
+            enum: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg', 'image/webp'],
         },
         size: {
             type: 'number',

--- a/apps/platform/src/storage/S3StorageProvider.ts
+++ b/apps/platform/src/storage/S3StorageProvider.ts
@@ -4,10 +4,14 @@ import { PassThrough } from 'stream'
 import { AWSConfig } from '../core/aws'
 import { StorageTypeConfig } from './Storage'
 import { ImageUploadTask, StorageProvider } from './StorageProvider'
+import App from '../app'
+import { combineURLs } from '../utilities'
 
 export interface S3Config extends StorageTypeConfig, AWSConfig {
     driver: 's3'
     bucket: string
+    endpoint: string
+    forcePathStyle: boolean
 }
 
 export class S3StorageProvider implements StorageProvider {
@@ -46,5 +50,12 @@ export class S3StorageProvider implements StorageProvider {
             Bucket: this.config.bucket,
             Key: filename,
         })
+    }
+
+    static url(path: string) {
+        const config = App.main.env.storage as S3Config
+        return config.endpoint && config.forcePathStyle
+            ? combineURLs([config.endpoint, config.bucket, path])
+            : combineURLs([`https://${config.bucket}.s3.amazonaws.com`, path])
     }
 }

--- a/apps/platform/src/storage/Storage.ts
+++ b/apps/platform/src/storage/Storage.ts
@@ -64,6 +64,11 @@ export default class Storage {
             return combineURLs([App.main.env.storage.baseUrl, path])
         }
 
+        // If we are using S3, provide a path based on endpoint if needed
+        if (App.main.env.storage.driver === 's3') {
+            return S3StorageProvider.url(path)
+        }
+
         // Otherwise default back to local path
         return `/uploads/${path}`
     }

--- a/apps/ui/src/ui/form/UploadField.tsx
+++ b/apps/ui/src/ui/form/UploadField.tsx
@@ -7,6 +7,7 @@ interface UploadFieldProps<X extends FieldValues, P extends FieldPath<X>> extend
     value?: FileList | null
     onChange?: (value: FileList) => void
     isUploading?: boolean
+    accept?: string
 }
 
 export default function UploadField<X extends FieldValues, P extends FieldPath<X>>(props: UploadFieldProps<X, P>) {
@@ -18,6 +19,7 @@ export default function UploadField<X extends FieldValues, P extends FieldPath<X
         name,
         required,
         isUploading = false,
+        accept = 'text/csv',
     } = props
     let { value, onChange } = props
     if (form) {
@@ -65,7 +67,7 @@ export default function UploadField<X extends FieldValues, P extends FieldPath<X
                 type="file"
                 id={id}
                 name={name}
-                accept="text/csv"
+                accept={accept}
                 required={required}
                 disabled={disabled ?? isUploading}
                 onChange={(event) => event.target.files && onChange?.(event.target.files)} />

--- a/apps/ui/src/views/campaign/ImageGalleryModal.tsx
+++ b/apps/ui/src/views/campaign/ImageGalleryModal.tsx
@@ -37,6 +37,7 @@ export default function ImageGalleryModal({ open, onClose, onInsert }: ImageGall
                     name="file"
                     label="File"
                     isUploading={upload !== undefined}
+                    accept={'image/*'}
                     required />
 
                 {results && <div className="images">

--- a/docs/docs/advanced/config.md
+++ b/docs/docs/advanced/config.md
@@ -32,7 +32,9 @@ Find below a list of all environment variables that can be set at launch to conf
 |--|--|--|
 | STORAGE_BASE_URL | string | true |
 | STORAGE_DRIVER | 's3' or 'local' | true |
-| AWS_S3_BUCKET | string | If driver is S3 |
+| STORAGE_S3_BUCKET | string | If driver is S3 |
+| STORAGE_S3_ENDPOINT | string | false |
+| STORAGE_S3_FORCE_PATH_STYLE | boolean | false |
 | AWS_REGION | string | If driver is S3 |
 | AWS_ACCESS_KEY_ID | string | If driver is S3 |
 | AWS_SECRET_ACCESS_KEY | string | If driver is S3 |

--- a/docs/docs/advanced/storage.md
+++ b/docs/docs/advanced/storage.md
@@ -1,0 +1,29 @@
+# Storage (Uploads)
+There are two different supported storage methods available to handle uploading assets for templates: 
+- Local
+- S3
+
+## Local
+This is the default storage method and no configuration is required. It will by default serve imagery from your base URL.
+
+## S3
+The S3 storage method allows for configuring any S3-compatible object storage service such as AWS S3, [Digital Ocean Spaces](https://docs.digitalocean.com/products/spaces/how-to/use-aws-sdks/#:~:text=To%20use%20Spaces%20with%20tools,where%20your%20bucket%20is%20located.), Minio, etc.
+
+Under the hood it is utilizing the AWS S3 SDK so please consult whatever service you are using as to what values should be used in what places.
+
+The URL that is generated for referencing each image can be overriden using the `STORAGE_BASE_URL` key.
+
+### Configuration
+| key | type | required | default |
+|--|--|--|--|
+| STORAGE_DRIVER | "s3" | true |
+| STORAGE_BASE_URL | string | true |
+| STORAGE_S3_BUCKET | string | true |
+| STORAGE_S3_ENDPOINT | string | false |
+| STORAGE_S3_FORCE_PATH_STYLE | boolean | false | false |
+| AWS_REGION | string | false | us-east-1 |
+| AWS_ACCESS_KEY_ID | string | true |
+| AWS_SECRET_ACCESS_KEY | string | true |
+
+### Use with CDN
+If you are utilizing a CDN in front of your bucket, you can set the URL of the CDN to be used for all images by utilizing the `STORAGE_BASE_URL` parameter. Utilizing this parameter will rewrite all image URLs to use that as the base url instead of the S3 endpoint.


### PR DESCRIPTION
Adds the `endpoint` field to the configuration allowed by the S3 storage method to allow for other S3-compatible clients to be used addressing the request in #337

Also adds docs and improves the upload process