### PR TITLE
Fixes regression that broke new event based journey entrances

### DIFF
--- a/apps/platform/src/journey/JourneyService.ts
+++ b/apps/platform/src/journey/JourneyService.ts
@@ -21,7 +21,7 @@ export const enterJourneysFromEvent = async (event: UserEvent, user?: User) => {
         .where('journeys.published', true)
         .where('journey_steps.type', JourneyEntrance.type)
         .whereJsonPath('journey_steps.data', '$.trigger', '=', 'event')
-        .whereJsonPath('journey_steps.data', '$.eventName', '=', event.name),
+        .whereJsonPath('journey_steps.data', '$.event_name', '=', event.name),
     )
 
     if (!entrances.length) return

--- a/apps/platform/src/journey/__tests__/JourneyService.spec.ts
+++ b/apps/platform/src/journey/__tests__/JourneyService.spec.ts
@@ -113,7 +113,7 @@ describe('JourneyService', () => {
                     type: 'entrance',
                     data: {
                         trigger: 'event',
-                        eventName: 'purchased gourd',
+                        event_name: 'purchased gourd',
                     },
                 },
             },


### PR DESCRIPTION
Fixes regression caused by #330 where new journeys created since that merge were not being appropriately picked up by the journey scheduler.

Updates test case to ensure its covered moving forward

Fixes #336 