### PR TITLE
Fixes bug where events for gates where not flattened

### DIFF
--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -309,7 +309,7 @@ export class JourneyGate extends JourneyStep {
 
         const params = {
             user: state.user.flatten(),
-            events,
+            events: events.map(e => e.flatten()),
             journey: state.stepData(),
         }
 


### PR DESCRIPTION
Properly flattens events before sending them to gates so that data parameters can be accessed without the `data` key in the path.

Fixes #344 