### PR TITLE
Allows for accessing journey data from campaign

### DIFF
--- a/apps/platform/src/render/index.ts
+++ b/apps/platform/src/render/index.ts
@@ -21,6 +21,7 @@ export interface Variables {
     context: RenderContext
     user: User
     event?: Record<string, any>
+    journey?: Record<string, any>
     project: Project
 }
 
@@ -71,10 +72,11 @@ export const Wrap = ({ html, preheader, variables: { user, context, project } }:
     return html
 }
 
-export default (template: string, { user, event, context }: Variables) => {
+export const Render = (template: string, { user, event, journey, context }: Variables) => {
     return compileTemplate(template)({
         user: user.flatten(),
         event,
+        journey,
         context,
         unsubscribeEmailUrl: unsubscribeEmailLink({
             userId: user.id,
@@ -84,3 +86,5 @@ export default (template: string, { user, event, context }: Variables) => {
         preferencesUrl: preferencesLink(user.id),
     })
 }
+
+export default Render


### PR DESCRIPTION
Like in other journey steps like User Update, the campaign action now allows for accessing journey data via the `journey` key. To access event data from a given step for example, a given campaign template would access `{{ journey.step_data_key.event.param }}`