### PR TITLE
Addresses some edge cases when a text send fails or is aborted

### DIFF
--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -62,6 +62,10 @@ export class CampaignSend extends Model {
     opened_at!: string | Date
     clicks!: number
     user_step_id?: number
+
+    get hasCompleted() {
+        return ['aborted', 'sent', 'failed', 'bounced'].includes(this.state)
+    }
 }
 
 export type CampaignSendParams = Pick<CampaignSend, 'campaign_id' | 'user_id' | 'state' | 'send_at'>

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -39,7 +39,7 @@ export async function loadSendJob<T extends TemplateType>({ campaign_id, user_id
 
     // If there is a send and it's in an aborted state or has already
     // sent, abort this job to prevent duplicate sends
-    if (send && (send.state === 'aborted' || send.state === 'sent')) return
+    if (send && send.hasCompleted) return
 
     // Fetch campaign and templates
     const campaign = await Campaign.find(campaign_id)

--- a/apps/platform/src/providers/text/TextJob.ts
+++ b/apps/platform/src/providers/text/TextJob.ts
@@ -44,12 +44,16 @@ export default class TextJob extends Job {
         try {
             await channel.send(template, data)
         } catch (error: any) {
+
+            // On error, mark as failed and notify just in case
             await updateSendState({
                 campaign,
                 user,
                 user_step_id: trigger.user_step_id,
                 state: 'failed',
             })
+            App.main.error.notify(error)
+            return
         }
 
         // Update send record


### PR DESCRIPTION
- If a text send fails, prevents the status from getting overridden
- Doesn't let a campaign send re-run or avoid its lock if it had previously failed