### PR TITLE
Fixes broken link when clicking on a subscription

### DIFF
--- a/apps/platform/src/subscriptions/Subscription.ts
+++ b/apps/platform/src/subscriptions/Subscription.ts
@@ -24,3 +24,4 @@ export class UserSubscription extends Model {
 }
 
 export type SubscriptionParams = Omit<Subscription, ModelParams>
+export type SubscriptionUpdateParams = Pick<SubscriptionParams, 'name'>

--- a/apps/platform/src/subscriptions/SubscriptionController.ts
+++ b/apps/platform/src/subscriptions/SubscriptionController.ts
@@ -2,8 +2,8 @@ import Router from '@koa/router'
 import App from '../app'
 import { RequestError } from '../core/errors'
 import { JSONSchemaType, validate } from '../core/validate'
-import Subscription, { SubscriptionParams, SubscriptionState, UserSubscription } from './Subscription'
-import { createSubscription, getSubscription, pagedSubscriptions, toggleSubscription, unsubscribe } from './SubscriptionService'
+import Subscription, { SubscriptionParams, SubscriptionState, SubscriptionUpdateParams, UserSubscription } from './Subscription'
+import { createSubscription, getSubscription, pagedSubscriptions, toggleSubscription, unsubscribe, updateSubscription } from './SubscriptionService'
 import SubscriptionError from './SubscriptionError'
 import { encodedLinkToParts } from '../render/LinkService'
 import { ProjectState } from '../auth/AuthMiddleware'
@@ -267,7 +267,7 @@ router.post('/', projectRoleMiddleware('admin'), async ctx => {
 
 router.param('subscriptionId', async (value, ctx, next) => {
     ctx.state.subscription = await getSubscription(parseInt(value), ctx.state.project.id)
-    if (!ctx.state.campaign) {
+    if (!ctx.state.subscription) {
         ctx.throw(404)
         return
     }
@@ -276,6 +276,23 @@ router.param('subscriptionId', async (value, ctx, next) => {
 
 router.get('/:subscriptionId', async ctx => {
     ctx.body = ctx.state.subscription
+})
+
+export const subscriptionUpdateSchema: JSONSchemaType<SubscriptionUpdateParams> = {
+    $id: 'subscriptionUpdate',
+    type: 'object',
+    required: ['name'],
+    properties: {
+        name: {
+            type: 'string',
+        },
+    },
+    additionalProperties: false,
+}
+router.patch('/:subscriptionId', async ctx => {
+    console.log('got here?')
+    const payload = validate(subscriptionUpdateSchema, ctx.request.body)
+    ctx.body = await updateSubscription(ctx.state.subscription!.id, payload)
 })
 
 export default router

--- a/apps/platform/src/subscriptions/SubscriptionService.ts
+++ b/apps/platform/src/subscriptions/SubscriptionService.ts
@@ -56,6 +56,10 @@ export const createSubscription = async (projectId: number, params: Subscription
     })
 }
 
+export const updateSubscription = async (id: number, params: Partial<SubscriptionParams>): Promise<Subscription> => {
+    return await Subscription.updateAndFetch(id, params)
+}
+
 export const subscriptionForChannel = async (channel: ChannelType, projectId: number): Promise<Subscription | undefined> => {
     return await Subscription.first(qb => qb.where('channel', channel).where('project_id', projectId))
 }

--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios'
 import { env } from './config/env'
-import { Admin, AuthMethod, Campaign, CampaignCreateParams, CampaignLaunchParams, CampaignUpdateParams, CampaignUser, Image, Journey, JourneyEntranceDetail, JourneyStepMap, JourneyUserStep, List, ListCreateParams, ListUpdateParams, Locale, Metric, Organization, OrganizationUpdateParams, Project, ProjectAdmin, ProjectAdminInviteParams, ProjectAdminParams, ProjectApiKey, ProjectApiKeyParams, Provider, ProviderCreateParams, ProviderMeta, ProviderUpdateParams, QueueMetric, RuleSuggestions, SearchParams, SearchResult, Subscription, SubscriptionParams, Tag, Template, TemplateCreateParams, TemplatePreviewParams, TemplateProofParams, TemplateUpdateParams, User, UserEvent, UserSubscription } from './types'
+import { Admin, AuthMethod, Campaign, CampaignCreateParams, CampaignLaunchParams, CampaignUpdateParams, CampaignUser, Image, Journey, JourneyEntranceDetail, JourneyStepMap, JourneyUserStep, List, ListCreateParams, ListUpdateParams, Locale, Metric, Organization, OrganizationUpdateParams, Project, ProjectAdmin, ProjectAdminInviteParams, ProjectAdminParams, ProjectApiKey, ProjectApiKeyParams, Provider, ProviderCreateParams, ProviderMeta, ProviderUpdateParams, QueueMetric, RuleSuggestions, SearchParams, SearchResult, Subscription, SubscriptionCreateParams, SubscriptionParams, SubscriptionUpdateParams, Tag, Template, TemplateCreateParams, TemplatePreviewParams, TemplateProofParams, TemplateUpdateParams, User, UserEvent, UserSubscription } from './types'
 
 function appendValue(params: URLSearchParams, name: string, value: unknown) {
     if (typeof value === 'undefined' || value === null || typeof value === 'function') return
@@ -248,7 +248,7 @@ const api = {
             .then(r => r.data),
     },
 
-    subscriptions: createProjectEntityPath<Subscription>('subscriptions'),
+    subscriptions: createProjectEntityPath<Subscription, SubscriptionCreateParams, SubscriptionUpdateParams>('subscriptions'),
 
     providers: {
         all: async (projectId: number | string) => await client

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -478,6 +478,8 @@ export interface Subscription {
     created_at: string
     updated_at: string
 }
+export type SubscriptionCreateParams = Pick<Subscription, 'name' | 'channel'>
+export type SubscriptionUpdateParams = Pick<SubscriptionCreateParams, 'name'>
 
 export type ProviderGroup = 'email' | 'text' | 'push' | 'webhook'
 export interface Provider {


### PR DESCRIPTION
In settings the subscription screen had a link where instead it should've been a static table. This instead updates that table to allow for at least editing the subscription name. The channel type cannot be changed after creation.

Fixes #371 