### PR TITLE
modal focus issue that kills latest chrome, dont show campaign type f…

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/parcelvoy/platform",
   "dependencies": {
     "@fontsource/inter": "^4.5.14",
-    "@headlessui/react": "1.7.13",
+    "@headlessui/react": "1.7.18",
     "@heroicons/react": "^2.0.11",
     "@monaco-editor/react": "^4.4.6",
     "@popperjs/core": "^2.11.6",
@@ -25,7 +25,7 @@
     "react": "^18.2.0",
     "react-charts": "^3.0.0-beta.57",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.33.0",
+    "react-hook-form": "7.51.1",
     "react-hot-toast": "^2.4.0",
     "react-popper": "^2.3.0",
     "react-router-dom": "^6.4.2",

--- a/apps/ui/src/ui/Modal.tsx
+++ b/apps/ui/src/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
-import { Fragment, PropsWithChildren, ReactNode, useRef } from 'react'
+import { Fragment, PropsWithChildren, ReactNode } from 'react'
 import Button from './Button'
 import { CloseIcon } from './icons'
 import './Modal.css'
@@ -27,14 +27,14 @@ export default function Modal({
     size,
     zIndex = 999,
 }: PropsWithChildren<ModalProps>) {
-    const ref = useRef<HTMLDivElement>(null)
     return (
         <Transition.Root show={open} as={Fragment}>
-            <Dialog as="div"
+            <Dialog
+                as="div"
                 className={`modal ${size ?? 'small'}`}
                 onClose={onClose}
                 style={{ zIndex }}
-                initialFocus={ref}>
+            >
                 <Transition.Child
                     as={Fragment}
                     enter="transition-enter"
@@ -85,7 +85,7 @@ export default function Modal({
                                     </Dialog.Description>
                                 )
                             }
-                            <div className="modal-content" ref={ref}>
+                            <div className="modal-content">
                                 {children}
                             </div>
                             {
@@ -96,12 +96,15 @@ export default function Modal({
                                 )
                             }
                             {
-                                size !== 'fullscreen' && <Button
-                                    className="modal-close"
-                                    size="tiny"
-                                    variant="plain"
-                                    icon={<CloseIcon />}
-                                    onClick={() => onClose(false)} />
+                                size !== 'fullscreen' && (
+                                    <Button
+                                        className="modal-close"
+                                        size="tiny"
+                                        variant="plain"
+                                        icon={<CloseIcon />}
+                                        onClick={() => onClose(false)}
+                                    />
+                                )
                             }
                         </Dialog.Panel>
                     </Transition.Child>

--- a/apps/ui/src/views/campaign/CampaignForm.tsx
+++ b/apps/ui/src/views/campaign/CampaignForm.tsx
@@ -233,7 +233,7 @@ const TypeSelection = ({ campaign, form }: { campaign?: Campaign, form: UseFormR
     </>
 }
 
-export function CampaignForm({ campaign, onSave }: CampaignEditParams) {
+export function CampaignForm({ campaign, onSave, type }: CampaignEditParams) {
     const [project] = useContext(ProjectContext)
 
     const [providers, setProviders] = useState<Provider[]>([])
@@ -275,7 +275,7 @@ export function CampaignForm({ campaign, onSave }: CampaignEditParams) {
     return (
         <FormWrapper<CampaignCreateParams>
             onSubmit={async (item) => await handleSave(item)}
-            defaultValues={campaign ?? { type: 'blast' }}
+            defaultValues={campaign ?? { type: type ?? 'blast' }}
             submitLabel="Save"
         >
             {form => (
@@ -289,7 +289,9 @@ export function CampaignForm({ campaign, onSave }: CampaignEditParams) {
                         form={form}
                         name="tags"
                     />
-                    <TypeSelection campaign={campaign} form={form} />
+                    {
+                        !type && <TypeSelection campaign={campaign} form={form} />
+                    }
                     {
                         campaign
                             ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource/inter": "^4.5.14",
-        "@headlessui/react": "1.7.13",
+        "@headlessui/react": "1.7.18",
         "@heroicons/react": "^2.0.11",
         "@monaco-editor/react": "^4.4.6",
         "@popperjs/core": "^2.11.6",
@@ -142,7 +142,7 @@
         "react": "^18.2.0",
         "react-charts": "^3.0.0-beta.57",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.33.0",
+        "react-hook-form": "7.51.1",
         "react-hot-toast": "^2.4.0",
         "react-popper": "^2.3.0",
         "react-router-dom": "^6.4.2",
@@ -4151,10 +4151,11 @@
       "dev": true
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.13.tgz",
-      "integrity": "sha512-9n+EQKRtD9266xIHXdY5MfiXPDfYwl7zBM7KOx2Ae3Gdgxy8QML1FkCMjq6AsOf0l6N9uvI4HcFtuFlenaldKg==",
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
         "client-only": "^0.0.1"
       },
       "engines": {
@@ -8242,6 +8243,31 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
+      "integrity": "sha512-YCzcbF/Ws/uZ0q3Z6fagH+JVhx4JLvbSflgldMgLsuvB8aXjZLLb3HvrEVxY480F9wFlBiXlvQxOyXb5ENPrNA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.1.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
+      "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -27000,9 +27026,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-hook-form": {
-      "version": "7.50.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
-      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "version": "7.51.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.1.tgz",
+      "integrity": "sha512-ifnBjl+kW0ksINHd+8C/Gp6a4eZOdWyvRv0UBaByShwU8JbVx5hTcTWEcd5VdybvmPTATkVVXk9npXArHmo56w==",
       "engines": {
         "node": ">=12.22.0"
       },


### PR DESCRIPTION
- trying to set the initial focus for modals onto a non-focusable element is for some reason killing the latest chrome when there are multiple of these at once. reverted to the default focus mechanism of headless ui, which seems to work better anyways.
- updated ui to not show type selector when creating a campaign for a journey
- bumped headless ui and react hook form versions