### PR TITLE
First member of an organization should be owner

### DIFF
--- a/apps/platform/src/auth/AuthProvider.ts
+++ b/apps/platform/src/auth/AuthProvider.ts
@@ -15,23 +15,26 @@ export default abstract class AuthProvider {
     abstract start(ctx: AuthContext): Promise<void>
     abstract validate(ctx: AuthContext): Promise<void>
 
-    async loadAuthOrganization(ctx: AuthContext, domain?: string) {
+    async loadAuthOrganization(ctx: AuthContext, domain?: string): Promise<{ organization: Organization, isNew: boolean }> {
 
         // If we have an organization or can find one by domain
         // we use that to start
         let organization = ctx.state.organization ?? await getOrganizationByDomain(domain)
-        if (organization) return organization
+        if (organization) return { organization, isNew: false }
 
         // If we are not in multi-org mode we always fall back to
         // a single organization
         if (!App.main.env.config.multiOrg) {
             organization = await getDefaultOrganization()
         }
-        if (organization) return organization
+        if (organization) return { organization, isNew: false }
 
         // If there is no organization at all or are in multi-org mode
         // and have no org for the user, create one
-        return await createOrganization(domain)
+        return {
+            organization: await createOrganization(domain),
+            isNew: true,
+        }
     }
 
     async login({ domain, ...params }: AuthAdminParams, ctx: AuthContext, redirect?: string): Promise<OAuthResponse> {
@@ -39,10 +42,11 @@ export default abstract class AuthProvider {
         // Check for existing, otherwise create one
         let admin = await getAdminByEmail(params.email)
         if (!admin) {
-            const organization = await this.loadAuthOrganization(ctx, domain)
+            const { organization, isNew } = await this.loadAuthOrganization(ctx, domain)
             admin = await Admin.insertAndFetch({
                 ...params,
                 organization_id: organization.id,
+                role: isNew ? 'owner' : 'member',
             })
         }
 


### PR DESCRIPTION
Fixes regression introduced in 1.3.5 where the first user in a new organization would not have the proper permissions to create projects. The first user should always be an owner.