### PR TITLE
Ensures the anonymous ID is passed along to analytics

### DIFF
--- a/apps/platform/src/providers/analytics/AnalyticsProvider.ts
+++ b/apps/platform/src/providers/analytics/AnalyticsProvider.ts
@@ -5,7 +5,10 @@ import Provider, { ProviderGroup } from '../Provider'
 
 export type AnalyticsProviderName = 'segment' | 'mixpanel' | 'posthog'
 
-export type AnalyticsUserEvent = UserEventParams & { external_id: string }
+export type AnalyticsUserEvent = UserEventParams & {
+    external_id: string
+    anonymous_id?: string
+}
 
 export type Convention = 'snake_case' | 'camel_case' | 'title_case'
 

--- a/apps/platform/src/providers/analytics/SegmentProvider.ts
+++ b/apps/platform/src/providers/analytics/SegmentProvider.ts
@@ -45,6 +45,7 @@ export default class SegmentAnalyticsProvider extends AnalyticsProvider {
 
         this.segment.track({
             userId: event.external_id,
+            anonymousId: event.anonymous_id,
             event: this.tranformEventName(event.name, this.event_name_convention),
             properties: event.data,
         })

--- a/apps/platform/src/users/UserEventRepository.ts
+++ b/apps/platform/src/users/UserEventRepository.ts
@@ -20,6 +20,7 @@ export const createEvent = async (
         const analytics = await loadAnalytics(user.project_id)
         analytics.track({
             external_id: user.external_id,
+            anonymous_id: user.anonymous_id,
             name,
             data: filter(data),
         })

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -116,7 +116,7 @@ export const createUser = async (projectId: number, { external_id, anonymous_id,
     await createEvent(user, {
         name: 'user_created',
         data: { ...fields, data, external_id, anonymous_id },
-    })
+    }, false)
 
     return user
 }


### PR DESCRIPTION
Currently only the external ID is passed but a user can be created without one which can cause an event to be triggered with no user association