### PR TITLE
Fixes duplicating journey "triggered" campaigns

### DIFF
--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -28,6 +28,9 @@ export const pagedCampaigns = async (params: PageParams, projectId: number) => {
         b => {
             b.where('project_id', projectId)
                 .whereNull('deleted_at')
+            if (params.filter?.type) {
+                b.where('type', params.filter.type)
+            }
             params.tag?.length && b.whereIn('id', createTagSubquery(Campaign, projectId, params.tag))
             return b
         },

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -350,7 +350,7 @@ export const abortCampaign = async (campaign: Campaign) => {
 export const duplicateCampaign = async (campaign: Campaign) => {
     const params: Partial<Campaign> = pick(campaign, ['project_id', 'list_ids', 'exclusion_list_ids', 'provider_id', 'subscription_id', 'channel', 'name', 'type'])
     params.name = `Copy of ${params.name}`
-    params.state = 'draft'
+    params.state = campaign.type === 'blast' ? 'draft' : 'running'
     const cloneId = await Campaign.insert(params)
     for (const template of campaign.templates) {
         await duplicateTemplate(template, cloneId)

--- a/apps/platform/src/core/searchParams.ts
+++ b/apps/platform/src/core/searchParams.ts
@@ -8,6 +8,7 @@ export interface PageParams {
     cursor?: string
     page?: 'prev' | 'next'
     q?: string
+    filter?: Record<string, any>
     tag?: string[]
     id?: number[]
 }
@@ -40,6 +41,10 @@ export const SearchSchema = (id: string, defaults?: Partial<PageParams>): JSONSc
             q: {
                 type: 'string',
                 nullable: true,
+            },
+            filter: {
+                nullable: true,
+                type: 'object',
             },
             sort: {
                 type: 'string',

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -93,6 +93,7 @@ export interface SearchParams {
     limit: number
     sort?: string
     direction?: string
+    filter?: Record<string, any>
     q?: string
     tag?: string[]
     id?: Array<number | string>

--- a/apps/ui/src/views/journey/steps/Action.tsx
+++ b/apps/ui/src/views/journey/steps/Action.tsx
@@ -64,7 +64,7 @@ export const actionStep: JourneyStepType<ActionConfig> = {
                 label={t('campaign')}
                 subtitle={t('send_campaign_desc')}
                 get={useCallback(async id => await api.campaigns.get(projectId, id), [projectId])}
-                search={useCallback(async q => await api.campaigns.search(projectId, { q, limit: 50 }), [projectId])}
+                search={useCallback(async q => await api.campaigns.search(projectId, { q, limit: 50, filter: { type: 'trigger' } }), [projectId])}
                 value={value.campaign_id}
                 onChange={campaign_id => onChange({ ...value, campaign_id })}
                 required


### PR DESCRIPTION
Currently duplicating a campaign moves it to a draft state, but you cant launch a triggered campaign as it should always be running. This fixes that issue and also prevents you from selecting non-triggered campaigns inside of journeys since they may not work properly.

Fixes #417 