### PR TITLE
Allows for uploading user created at dates statically

### DIFF
--- a/apps/platform/src/users/User.ts
+++ b/apps/platform/src/users/User.ts
@@ -95,3 +95,4 @@ export class User extends Model {
 }
 
 export type UserParams = Partial<Pick<User, 'email' | 'phone' | 'timezone' |'locale' | 'data'>> & ClientIdentity
+export type UserInternalParams = Partial<Pick<User, 'email' | 'phone' | 'timezone' |'locale' | 'created_at' | 'data'>> & ClientIdentity

--- a/apps/platform/src/users/UserImport.ts
+++ b/apps/platform/src/users/UserImport.ts
@@ -27,7 +27,7 @@ export const importUsers = async ({ project_id, stream, list_id }: UserImport) =
     )
     const parser = stream.file.pipe(parse(options))
     for await (const row of parser) {
-        const { external_id, email, phone, timezone, locale, ...data } = cleanRow(row)
+        const { external_id, email, phone, timezone, locale, created_at, ...data } = cleanRow(row)
         if (!external_id) throw new RequestError('Every upload must contain a column `external_id` which contains the identifier for that user.')
         await chunker.add(UserPatchJob.from({
             project_id,
@@ -38,6 +38,7 @@ export const importUsers = async ({ project_id, stream, list_id }: UserImport) =
                 timezone,
                 locale,
                 data,
+                created_at,
             },
             options: {
                 join_list_id: list_id,
@@ -54,16 +55,17 @@ export const importUsers = async ({ project_id, stream, list_id }: UserImport) =
 
 const cleanRow = (row: Record<string, any>): Record<string, any> => {
     return Object.keys(row).reduce((acc, curr) => {
-        acc[curr] = cleanCell(row[curr])
+        acc[curr] = cleanCell(row[curr], curr)
         return acc
     }, {} as Record<string, any>)
 }
 
-const cleanCell = (value: any) => {
+const cleanCell = (value: any, key: string) => {
     if (typeof value === 'string') {
         if (value.toLowerCase() === 'false') return false
         if (value.toLowerCase() === 'true') return true
         if (value === 'NULL' || value == null || value === 'undefined' || value === '') return undefined
+        if (key.includes('_at')) return new Date(value)
     }
     return value
 }

--- a/apps/platform/src/users/UserPatchJob.ts
+++ b/apps/platform/src/users/UserPatchJob.ts
@@ -1,4 +1,4 @@
-import { User, UserParams } from './User'
+import { User, UserInternalParams } from './User'
 import { Job } from '../queue'
 import { createUser, getUsersFromIdentity } from './UserRepository'
 import { addUserToList, getList, updateUsersLists } from '../lists/ListService'
@@ -7,7 +7,7 @@ import { matchingRulesForUser } from '../rules/RuleService'
 
 interface UserPatchTrigger {
     project_id: number
-    user: UserParams
+    user: UserInternalParams
     options?: {
         join_list_id?: number
         skip_list_updating?: boolean

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -3,7 +3,7 @@ import { ClientAliasParams, ClientIdentity } from '../client/Client'
 import { PageParams } from '../core/searchParams'
 import { RetryError } from '../queue/Job'
 import { subscribeAll } from '../subscriptions/SubscriptionService'
-import { Device, DeviceParams, User, UserParams } from '../users/User'
+import { Device, DeviceParams, User, UserInternalParams } from '../users/User'
 import { uuid } from '../utilities'
 import { getRuleEventNames } from '../rules/RuleHelpers'
 import { UserEvent } from './UserEvent'
@@ -107,12 +107,13 @@ export const aliasUser = async (projectId: number, {
     return await User.updateAndFetch(previous.id, { external_id })
 }
 
-export const createUser = async (projectId: number, { external_id, anonymous_id, data, ...fields }: UserParams) => {
+export const createUser = async (projectId: number, { external_id, anonymous_id, data, created_at, ...fields }: UserInternalParams) => {
     const user = await User.insertAndFetch({
         project_id: projectId,
         anonymous_id: anonymous_id ?? uuid(),
         external_id,
         data: data ?? {},
+        created_at: created_at ? new Date(created_at) : new Date(),
         ...fields,
     })
 

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -203,6 +203,7 @@ export interface User {
     locale?: string
     data: Record<string, any>
     devices?: Device[]
+    created_at?: Date
 }
 
 export interface Device {

--- a/apps/ui/src/views/users/UserDetailAttrs.tsx
+++ b/apps/ui/src/views/users/UserDetailAttrs.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from 'react-i18next'
 
 export default function UserDetail() {
     const { t } = useTranslation()
-    const [{ external_id, email, phone, timezone, locale, devices, data }] = useContext(UserContext)
+    const [{ external_id, email, phone, timezone, locale, created_at, devices, data }] = useContext(UserContext)
 
     return <>
         <Heading size="h3" title={t('details')} />
         <section className="container">
-            <JsonPreview value={{ external_id, email, phone, timezone, locale, devices, ...data }} />
+            <JsonPreview value={{ external_id, email, phone, timezone, locale, devices, created_at, ...data }} />
         </section>
     </>
 }

--- a/docs/docs/how-to/lists.md
+++ b/docs/docs/how-to/lists.md
@@ -20,4 +20,5 @@ You can create lists that contain fixed data that can be uploaded via CSV. When 
 - `email`: The users email
 - `phone`: The users phone number with country code
 - `timezone`: The users timezone provided in IANA format (America/Chicago)
-- `locale`: The language 
+- `locale`: The language
+- `created_at`: When a user was created to override internal time setting. Must be in ISO 8601 format


### PR DESCRIPTION
When creating a static list, you can now pass in a `created_at` field which will override the default setting of that field for users created allowing you to set it to times in the past. This field accepts a string ISO 8601 date.

Fixes #416 