### PR TITLE
Fixes org & role onboarding setup for basic auth

### DIFF
--- a/apps/platform/src/auth/BasicAuthProvider.ts
+++ b/apps/platform/src/auth/BasicAuthProvider.ts
@@ -1,10 +1,8 @@
 import { Context } from 'koa'
 import { AuthTypeConfig } from './Auth'
-import { getAdminByEmail } from './AdminRepository'
 import AuthProvider from './AuthProvider'
 import App from '../app'
 import { combineURLs, firstQueryParam } from '../utilities'
-import Admin from './Admin'
 import { RequestError } from '../core/errors'
 import AuthError from './AuthError'
 
@@ -40,13 +38,7 @@ export default class BasicAuthProvider extends AuthProvider {
             throw new RequestError(AuthError.InvalidCredentials)
         }
 
-        // Find admin, otherwise first time, create
-        let admin = await getAdminByEmail(email)
-        if (!admin) {
-            admin = await Admin.insertAndFetch({ email, first_name: 'Admin' })
-        }
-
         // Process the login
-        await this.login({ email, domain: 'local' }, ctx)
+        await this.login({ email, first_name: 'Admin', domain: 'local' }, ctx)
     }
 }


### PR DESCRIPTION
Basic auth had some extra superfluous logic that was preventing the organization creation and role permissioning from running properly. This fixes the issue that if you are setting up Parcelvoy for the first time using basic auth you wont have access to manage the organization or projects. This issue does not affect any other authentication method.

Fixes #415 and #399