### PR TITLE
Updates the historical migration for creating an org

### DIFF
--- a/apps/platform/db/migrations/20230514192033_add_organization.js
+++ b/apps/platform/db/migrations/20230514192033_add_organization.js
@@ -26,8 +26,8 @@ exports.up = async function(knex) {
             .after('id')
     })
 
-    const admins = await knex('admins').count('*')
-    if (admins > 1) {
+    const admins = await knex('admins').count({ count: '*' }).first()
+    if (admins.count > 1) {
         const orgId = await knex('organizations').insert({ id: 1, username: 'local' })
         await knex('projects').update({ organization_id: orgId }).whereNull('organization_id')
         await knex('admins').update({ organization_id: orgId }).whereNull('organization_id')

--- a/apps/platform/db/migrations/20230514192033_add_organization.js
+++ b/apps/platform/db/migrations/20230514192033_add_organization.js
@@ -26,9 +26,12 @@ exports.up = async function(knex) {
             .after('id')
     })
 
-    const orgId = await knex('organizations').insert({ id: 1, username: 'local' })
-    await knex('projects').update({ organization_id: orgId }).whereNull('organization_id')
-    await knex('admins').update({ organization_id: orgId }).whereNull('organization_id')
+    const admins = await knex('admins').count('*')
+    if (admins > 1) {
+        const orgId = await knex('organizations').insert({ id: 1, username: 'local' })
+        await knex('projects').update({ organization_id: orgId }).whereNull('organization_id')
+        await knex('admins').update({ organization_id: orgId }).whereNull('organization_id')
+    }
 }
 
 exports.down = async function(knex) {


### PR DESCRIPTION
The migration for creating the organizations table also tried to backfill an organization for existing installations but had no logical checks to make sure it wasn't running for new installations as well. This updates that historical migration to prevent it from happening moving forward for users. Existing users before this PR may need to link their admin record to a organization or change the role of the admin to `owner`

Fixes #415 