### PR TITLE
Fixes loophole where a failed send would cause a journey to stall

### DIFF
--- a/apps/platform/db/migrations/20240315211220_add_reference_to_campaign_send.js
+++ b/apps/platform/db/migrations/20240315211220_add_reference_to_campaign_send.js
@@ -6,7 +6,7 @@ exports.up = async function(knex) {
             .defaultTo('0')
     })
 
-    await knex.raw('UPDATE campaign_sends SET reference_id = user_step_id, reference_type = "journal"')
+    await knex.raw('UPDATE campaign_sends SET reference_id = user_step_id, reference_type = "journey"')
 
     await knex.schema.alterTable('campaign_sends', function(table) {
         table.unique(['user_id', 'campaign_id', 'reference_id'])

--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -11,7 +11,7 @@ import Rule from '../rules/Rule'
 import { check } from '../rules/RuleEngine'
 import App from '../app'
 import { RRule } from 'rrule'
-import { CampaignSend } from '../campaigns/Campaign'
+import { CampaignSend, CampaignSendReferenceType } from '../campaigns/Campaign'
 import { createEvent } from '../users/UserEventRepository'
 import { JourneyState } from './JourneyState'
 
@@ -268,13 +268,18 @@ export class JourneyAction extends JourneyStep {
         state.job(async () => {
             let send_id = await getCampaignSend(campaign.id, state.user.id, `${userStep.id}`).then(s => s?.id)
 
+            const reference = {
+                reference_id: `${userStep.id}`,
+                reference_type: 'journey' as CampaignSendReferenceType,
+            }
+
             if (!send_id) {
                 send_id = await CampaignSend.insert({
                     campaign_id: campaign.id,
                     user_id: state.user.id,
                     state: 'pending',
                     send_at: new Date(),
-                    reference_id: `${userStep.id}`,
+                    ...reference,
                 })
             }
 
@@ -282,7 +287,7 @@ export class JourneyAction extends JourneyStep {
                 campaign,
                 user: state.user,
                 send_id,
-                reference_id: `${userStep.id}`,
+                ...reference,
             })
         })
     }

--- a/apps/platform/src/providers/webhook/WebhookJob.ts
+++ b/apps/platform/src/providers/webhook/WebhookJob.ts
@@ -4,7 +4,6 @@ import { WebhookTemplate } from '../../render/Template'
 import { updateSendState } from '../../campaigns/CampaignService'
 import { failSend, finalizeSend, loadSendJob, messageLock, prepareSend } from '../MessageTriggerService'
 import { loadWebhookChannel } from '.'
-import { JourneyUserStep } from '../../journey/JourneyStep'
 import { releaseLock } from '../../core/Lock'
 
 export default class WebhookJob extends Job {
@@ -39,15 +38,6 @@ export default class WebhookJob extends Job {
         try {
             const result = await channel.send(template, data)
             await finalizeSend(data, result)
-
-            if (result.response
-                && trigger.reference_id
-                && trigger.reference_type === 'journey'
-            ) {
-                await JourneyUserStep.update(q => q.where('id', trigger.reference_id), {
-                    data: { response: result.response },
-                })
-            }
         } catch (error: any) {
             await failSend(data, error)
         } finally {

--- a/apps/ui/public/locales/en.json
+++ b/apps/ui/public/locales/en.json
@@ -1,6 +1,7 @@
 {
     "abort_campaign": "Abort Campaign",
     "aborted": "Aborted",
+    "action": "Action",
     "add_admin": "Add Admin",
     "add_admin_description": "Add a new admin to this organization. Admins have full access to all projects and settings, members can only access projects they are a part of.",
     "add_list": "Add List",

--- a/apps/ui/public/locales/es.json
+++ b/apps/ui/public/locales/es.json
@@ -1,6 +1,7 @@
 {
     "abort_campaign": "Cancelar campaña",
     "aborted": "Cancellado",
+    "action": "Acción",
     "add_admin": "Añadir Admin",
     "add_admin_description": "Añade un nuevo administrador a esta organización. Los administradores tienen acceso completo a todos los proyectos y ajustes, los miembros sólo pueden acceder a los proyectos de los que forman parte.",
     "add_list": "Añadir lista",


### PR DESCRIPTION
For campaign sends associated with journey steps, if a given step where to fail the journey would not be notified causing that users journey to stall out. This addresses that issue and also cleans up a bit of other journey/campaign interaction code.