### PR TITLE
Improves precision of list total counting

### DIFF
--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -317,11 +317,21 @@ export const listsForRule = async (ruleUuids: string[], projectId: number): Prom
     ) as DynamicList[]
 }
 
-export const listUserCount = async (listId: number, since?: Date): Promise<number> => {
+interface CountRange {
+    sinceDate?: Date
+    sinceId?: number
+    untilId?: number
+}
+
+export const listUserCount = async (listId: number, since?: CountRange): Promise<number> => {
     return await UserList.count(qb => {
         qb.where('list_id', listId)
-        if (since) {
-            qb.where('created_at', '>=', since)
+        if (since && since.sinceDate) {
+            qb.where('created_at', '>=', since.sinceDate)
+            if (since.sinceId && since.untilId) {
+                qb.where('id', '>', since.sinceId)
+                    .where('id', '<=', since.untilId)
+            }
         }
         return qb
     })

--- a/apps/platform/src/lists/ListStatsJob.ts
+++ b/apps/platform/src/lists/ListStatsJob.ts
@@ -1,26 +1,34 @@
+import { setMilliseconds } from 'date-fns'
 import App from '../app'
 import { cacheGet, cacheSet } from '../config/redis'
 import { Job } from '../queue'
+import { UserList } from './List'
 import { getList, listUserCount, updateListState } from './ListService'
 
 interface ListStatsParams {
     listId: number
     projectId: number
+    reset?: boolean
 }
 
 interface ListStatCache {
     users_count: number
     date: number
+    id: number
 }
 
 export default class ListStatsJob extends Job {
     static $name = 'list_stats_job'
 
-    static from(listId: number, projectId: number): ListStatsJob {
-        return new this({ listId, projectId })
+    static from(
+        listId: number,
+        projectId: number,
+        reset = false,
+    ): ListStatsJob {
+        return new this({ listId, projectId, reset })
     }
 
-    static async handler({ listId, projectId }: ListStatsParams) {
+    static async handler({ listId, projectId, reset = false }: ListStatsParams) {
 
         const list = await getList(listId, projectId)
         if (!list) return
@@ -30,14 +38,25 @@ export default class ListStatsJob extends Job {
         const value = await cacheGet<ListStatCache>(App.main.redis, key)
         let date: Date | undefined
         let previousCount = 0
-        if (value) {
+        let previousId = 0
+        if (value && !reset) {
             date = new Date(value.date)
             previousCount = value.users_count
+            previousId = value.id
         }
 
         // Get values since the cached values and add them to previous
-        const newDate = new Date()
-        const count = previousCount + await listUserCount(list.id, date)
+        const newDate = setMilliseconds(Date.now(), 0)
+        const latest = await UserList.first(
+            qb => qb.where('list_id', list.id)
+                .orderBy('id', 'desc')
+                .limit(1),
+        )
+        const count = previousCount + await listUserCount(list.id, {
+            sinceDate: date,
+            sinceId: previousId,
+            untilId: latest?.id,
+        })
 
         // Update the list with the new totals
         await updateListState(list.id, { users_count: count })
@@ -46,6 +65,7 @@ export default class ListStatsJob extends Job {
         await cacheSet(App.main.redis, key, {
             users_count: count,
             date: newDate.getTime(),
+            id: latest?.id ?? 0,
         }, 60 * 60 * 24)
     }
 }

--- a/apps/platform/src/users/UserImport.ts
+++ b/apps/platform/src/users/UserImport.ts
@@ -49,7 +49,7 @@ export const importUsers = async ({ project_id, stream, list_id }: UserImport) =
 
     // Generate preliminary list count
     if (list_id) {
-        await ListStatsJob.from(list_id, project_id).queue()
+        await ListStatsJob.from(list_id, project_id, true).delay(2000).queue()
     }
 }
 


### PR DESCRIPTION
The timestamp field on the `user_list` table didn't have enough precision to accurately handle segmented counting. This adds the identifier as a field to further enhance the range that is being counted