### PR TITLE
Move unsubscribe URLs to be safe links to prevent escaping

### DIFF
--- a/apps/platform/src/render/LinkService.ts
+++ b/apps/platform/src/render/LinkService.ts
@@ -64,13 +64,12 @@ export const encodedLinkToParts = async (link: string | URL): Promise<TrackedLin
 }
 
 export const clickWrapHtml = (html: string, params: TrackedLinkParams) => {
-    const regex = /href\s*=\s*(['"])(https?:\/\/.+?)\1/gi
+    const regex = /a.*href\s*=\s*(['"])(https?:\/\/.+?)\1/gi
     let link
 
     while ((link = regex.exec(html)) !== null) {
         const redirect = link[2]
 
-        // Otherwise create a link wrapper around the value
         html = html.replace(
             redirect,
             paramsToEncodedLink({ ...params, redirect, path: 'c' }),

--- a/apps/platform/src/render/index.ts
+++ b/apps/platform/src/render/index.ts
@@ -79,12 +79,12 @@ export const Render = (template: string, { user, event, journey, context }: Vari
         event,
         journey,
         context,
-        unsubscribeEmailUrl: unsubscribeEmailLink({
+        unsubscribeEmailUrl: new Handlebars.SafeString(unsubscribeEmailLink({
             userId: user.id,
             campaignId: context?.campaign_id,
             referenceId: context.reference_id,
-        }),
-        preferencesUrl: preferencesLink(user.id),
+        })),
+        preferencesUrl: new Handlebars.SafeString(preferencesLink(user.id)),
     })
 }
 

--- a/docs/docs/how-to/campaigns/templates.md
+++ b/docs/docs/how-to/campaigns/templates.md
@@ -471,3 +471,17 @@ Decode a Uniform Resource Identifier (URI) component.
 ```handlebars
 {{ decodeURI url }}
 ```
+
+### Subscription
+
+#### Unsubscribe Email
+Get a url to unsubscribe a user from a given email subscription channel.
+```handlebars
+{{ unsubscribeEmailUrl }}
+```
+
+#### Preference Center
+Get a url to navigate a user to a page where they can manage what subscription channels they are subscribed to.
+```handlebars
+{{ preferencesUrl }}
+```

--- a/docs/docs/how-to/settings/subscriptions.md
+++ b/docs/docs/how-to/settings/subscriptions.md
@@ -1,2 +1,14 @@
 # Subscription Group
 All communication between you and your users happens across providers, but what communications they receive is based on subscription states. You can setup as many different subscriptions as you want and what provider they go across. Users are then able to opt-in or opt-out of any given subscription to determine if they want to continue receiving that type of communication. As an example, you could setup separate subscription groups for deals vs for weekly inspiration and let the user decide to opt out of one but not the other.
+
+## Unsubscribe
+In most jurisdictions you must provide users with a way to stop receiving communications from you. To provide these options for users, use one of the options below.
+
+### Preference Center
+There is a default preference center available for users to opt out of all communication channels. The URL for this center for a given user can be accessed inside of any message that is sent by using the Handlebars variable: `{{ preferencesUrl }}`
+
+### Email
+To unsubscribe from the subscription channel that a given email is coming from you can provide users with a one-click unsubscribe link. This can be accessed via the Handlebars variable `{{ unsubscribeEmailUrl }}`
+
+### SMS (Text Message)
+If you have properly setup inbound SMS with your given provider, a user can unsubscribe by messaging the word `STOP` to the number that they have received the text message from.


### PR DESCRIPTION
Previously if you had link wrapping enabled you would have to use `{{{ unsubscribeEmailUrl }}}` (triple bracket) to get to the URL since it would have tags that should not be escaped. This was not called out anywhere and could definitely be problematic so this PR resolves and problem and improves documentation.

Also improves what elements are click wrapped.

Fixes #440 