### PR TITLE
Allow scheduling journey sends once

### DIFF
--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -1,4 +1,4 @@
-import { add, addDays, addHours, addMinutes, isFuture, isPast, parse } from 'date-fns'
+import { add, addDays, addHours, addMinutes, isEqual, isFuture, isPast, parse } from 'date-fns'
 import Model from '../core/Model'
 import { User } from '../users/User'
 import { getCampaign, getCampaignSend, triggerCampaignSend } from '../campaigns/CampaignService'
@@ -128,6 +128,16 @@ export class JourneyEntrance extends JourneyStep {
 
         if (this.schedule) {
             try {
+                const rule = RRule.fromString(this.schedule)
+
+                // If there is no frequency, only run once
+                if (!rule.options.freq) {
+                    if (isEqual(rule.options.dtstart, after)) {
+                        return null
+                    }
+                    return rule.options.dtstart
+                }
+
                 return RRule.fromString(this.schedule).after(after)
             } catch (err) {
                 App.main.error.notify(err as Error, {

--- a/apps/platform/src/journey/ScheduledEntranceOrchestratorJob.ts
+++ b/apps/platform/src/journey/ScheduledEntranceOrchestratorJob.ts
@@ -16,6 +16,7 @@ export default class ScheduledEntranceOrchestratorJob extends Job {
             .whereNull('journeys.deleted_at')
             .where('journey_steps.type', JourneyEntrance.type)
             .whereJsonPath('journey_steps.data', '$.trigger', '=', 'schedule')
+            .whereNotNull('journey_steps.next_scheduled_at')
             .where('journey_steps.next_scheduled_at', '<=', new Date()),
         )
 

--- a/apps/ui/src/ui/form/RadioInput.css
+++ b/apps/ui/src/ui/form/RadioInput.css
@@ -12,6 +12,10 @@
     box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05);
 }
 
+.options-group .options label {
+    margin: 0;
+}
+
 .options-group .option {
     flex-grow: 1;
     border-radius: var(--border-radius-inner);

--- a/apps/ui/src/views/journey/steps/Entrance.tsx
+++ b/apps/ui/src/views/journey/steps/Entrance.tsx
@@ -103,14 +103,19 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
             let s = ''
             if (schedule) {
                 try {
-                    s = RRule.fromString(schedule).toText()
+                    const rule = RRule.fromString(schedule)
+                    if (rule.options.freq) {
+                        s = rule.toText()
+                    } else {
+                        s = 'once'
+                    }
                 } catch {}
             }
             return (
                 <div style={{ maxWidth: 300 }}>
                     {t('entrance_add_everyone_from') + ' '}
                     <strong>
-                        {list?.name ?? '--'}
+                        {list?.name ?? <>&#8211;</>}
                     </strong>
                     {' '}
                     {s}
@@ -215,7 +220,7 @@ export const entranceStep: JourneyStepType<EntranceConfig> = {
                     )
                 }
                 {
-                    !!stepId && (
+                    !!stepId && value.trigger === 'none' && (
                         <div style={{ maxWidth: 600 }}>
                             <CodeExample
                                 title={t('entrance_trigger')}


### PR DESCRIPTION
Improves scheduling users to enter a journey by allowing for a single time schedule instead of just a recurring schedule.