### PR TITLE
Fixes tags not showing until page reload

### DIFF
--- a/apps/platform/src/journey/JourneyRepository.ts
+++ b/apps/platform/src/journey/JourneyRepository.ts
@@ -61,7 +61,7 @@ export const getJourney = async (id: number, projectId: number): Promise<Journey
 }
 
 export const updateJourney = async (id: number, { tags, ...params }: UpdateJourneyParams, db = App.main.db): Promise<Journey> => {
-    return db.transaction(async trx => {
+    const journey = await db.transaction(async trx => {
         const journey = await Journey.updateAndFetch(id, params, trx)
         if (tags) {
             await setTags({
@@ -73,6 +73,8 @@ export const updateJourney = async (id: number, { tags, ...params }: UpdateJourn
         }
         return journey
     })
+
+    return await getJourney(id, journey.project_id)
 }
 
 export const deleteJourney = async (id: number, projectId: number): Promise<void> => {

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -140,7 +140,7 @@ export const updateList = async (list: List, { tags, rule, published, ...params 
         await ListPopulateJob.from(list.id, list.project_id).queue()
     }
 
-    return list
+    return await getList(list.id, list.project_id)
 }
 
 export const archiveList = async (id: number, projectId: number) => {

--- a/apps/ui/src/views/users/ListDetail.tsx
+++ b/apps/ui/src/views/users/ListDetail.tsx
@@ -42,8 +42,8 @@ export default function ListDetail() {
     const state = useSearchTableState(useCallback(async params => await api.lists.users(project.id, list.id, params), [list, project]))
     const route = useRoute()
 
-    const saveList = async ({ name, rule, published }: ListUpdateParams) => {
-        const value = await api.lists.update(project.id, list.id, { name, rule, published })
+    const saveList = async ({ name, rule, published, tags }: ListUpdateParams) => {
+        const value = await api.lists.update(project.id, list.id, { name, rule, published, tags })
         setIsEditListOpen(false)
         setIsDialogOpen(true)
         setList(value)
@@ -110,9 +110,9 @@ export default function ListDetail() {
                 onClose={() => setIsEditListOpen(false)}
                 title={t('edit_list')}>
                 <FormWrapper<Omit<ListUpdateParams, 'rule'>>
-                    onSubmit={async ({ name, published }) => await saveList({ name, published })}
+                    onSubmit={async ({ name, published, tags }) => await saveList({ name, published, tags })}
                     submitLabel={t('save')}
-                    defaultValues={{ name: list.name }}
+                    defaultValues={{ name: list.name, tags: list.tags }}
                 >
                     {form => (
                         <>


### PR DESCRIPTION
Tags wouldn't reflect as set in the UI until after the page was reloaded since the response from the patch request wasn't including the relationship properly

Fixes #452 