### PR TITLE
Adds better support for inbound SMS

### DIFF
--- a/apps/platform/db/migrations/20240419015246_add_project_text_help.js
+++ b/apps/platform/db/migrations/20240419015246_add_project_text_help.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+    await knex.schema.table('projects', function(table) {
+        table.string('text_help_message', 255)
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('projects', function(table) {
+        table.dropColumn('text_help_message')
+    })
+}

--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -464,7 +464,6 @@ export class JourneyBalancer extends JourneyStep {
             hour: 60 * 60 * 1000,
             day: 24 * 60 * 60 * 1000,
         }
-        console.log(intervals[this.rate_interval], this.rate_interval)
         return intervals[this.rate_interval]
     }
 }

--- a/apps/platform/src/projects/Project.ts
+++ b/apps/platform/src/projects/Project.ts
@@ -8,6 +8,7 @@ export default class Project extends Model {
     locale!: string
     timezone!: string
     text_opt_out_message?: string
+    text_help_message?: string
     link_wrap?: boolean
 }
 

--- a/apps/platform/src/projects/ProjectController.ts
+++ b/apps/platform/src/projects/ProjectController.ts
@@ -85,6 +85,10 @@ const projectCreateParams: JSONSchemaType<ProjectParams> = {
             type: 'string',
             nullable: true,
         },
+        text_help_message: {
+            type: 'string',
+            nullable: true,
+        },
         link_wrap: {
             type: 'boolean',
             nullable: true,
@@ -134,6 +138,10 @@ const projectUpdateParams: JSONSchemaType<Partial<ProjectParams>> = {
             nullable: true,
         },
         text_opt_out_message: {
+            type: 'string',
+            nullable: true,
+        },
+        text_help_message: {
             type: 'string',
             nullable: true,
         },

--- a/apps/platform/src/providers/text/HttpSMSProvider.ts
+++ b/apps/platform/src/providers/text/HttpSMSProvider.ts
@@ -77,6 +77,6 @@ export default class HttpSMSTextProvider extends TextProvider {
 
     static controllers(): ProviderControllers {
         const admin = createController('text', this)
-        return { admin, public: this.unsubscribe(this.namespace) }
+        return { admin, public: this.inbound(this.namespace) }
     }
 }

--- a/apps/platform/src/providers/text/NexmoTextProvider.ts
+++ b/apps/platform/src/providers/text/NexmoTextProvider.ts
@@ -90,6 +90,6 @@ export default class NexmoTextProvider extends TextProvider {
 
     static controllers(): ProviderControllers {
         const admin = createController('text', this)
-        return { admin, public: this.unsubscribe(this.namespace) }
+        return { admin, public: this.inbound(this.namespace) }
     }
 }

--- a/apps/platform/src/providers/text/PlivoTextProvider.ts
+++ b/apps/platform/src/providers/text/PlivoTextProvider.ts
@@ -85,6 +85,6 @@ export default class PlivoTextProvider extends TextProvider {
 
     static controllers(): ProviderControllers {
         const admin = createController('text', this)
-        return { admin, public: this.unsubscribe(this.namespace) }
+        return { admin, public: this.inbound(this.namespace) }
     }
 }

--- a/apps/platform/src/providers/text/TextProvider.ts
+++ b/apps/platform/src/providers/text/TextProvider.ts
@@ -3,6 +3,10 @@ import { loadTextChannel } from '.'
 import { unsubscribeSms } from '../../subscriptions/SubscriptionService'
 import Provider, { ProviderGroup } from '../Provider'
 import { InboundTextMessage, TextMessage, TextResponse } from './TextMessage'
+import { Context } from 'koa'
+import { getUserFromPhone } from '../../users/UserRepository'
+import { getProject } from '../../projects/ProjectService'
+import { EventPostJob } from '../../jobs'
 
 export type TextProviderName = 'nexmo' | 'plivo' | 'twilio' | 'logger'
 
@@ -12,20 +16,55 @@ export abstract class TextProvider extends Provider {
 
     static get group() { return 'text' as ProviderGroup }
 
-    static unsubscribe(namespace: string) {
+    static inbound(namespace: string) {
         const router = new Router<{ provider: Provider }>()
-        router.post(`/${namespace}/unsubscribe`, async ctx => {
-            const channel = await loadTextChannel(ctx.state.provider.id)
-            if (!channel) {
-                ctx.status = 404
-                return
-            }
 
-            // Always return with positive status code
+        const inbound = async (ctx: Context) => {
+            const provider = ctx.state.provider
+
+            // Load in the required components to properly parse the message
+            const channel = await loadTextChannel(provider.id)
+            const project = await getProject(provider.project_id)
+            const message = channel?.provider.parseInbound(ctx.request.body)
+            if (!channel || !project || !message) ctx.throw(404)
+
+            // Find the user from the inbound text message
+            const user = await getUserFromPhone(provider.project_id, message.from)
+            if (!user) ctx.throw(404)
+
+            // If we've made it this far, always respond with success so webhooks
+            // don't double trigger
             ctx.status = 204
 
-            await unsubscribeSms(channel.provider, ctx.request.body)
-        })
+            // If the message includes the word STOP unsubscribe immediately
+            if (message.text.toLowerCase().includes('stop')) {
+                await unsubscribeSms(project.id, user)
+
+            // If the message includes the word HELP, send the help message
+            } else if (message.text.toLowerCase().includes('help') && project.text_help_message) {
+                channel.provider.send({
+                    to: message.from,
+                    text: project.text_help_message,
+                })
+
+            // Otherwise create an event so journeys can trigger off of the message
+            } else {
+                await EventPostJob.from({
+                    project_id: project.id,
+                    event: {
+                        name: 'text_inbound',
+                        external_id: user.external_id,
+                        anonymous_id: user.anonymous_id,
+                        data: { message },
+                    },
+                }).queue()
+            }
+        }
+
+        // Register for general `inbound` path but also deprecated `unsubscribe`
+        router.post(`/${namespace}/inbound`, inbound)
+        router.post(`/${namespace}/unsubscribe`, inbound)
+
         return router
     }
 }

--- a/apps/platform/src/providers/text/TwilioTextProvider.ts
+++ b/apps/platform/src/providers/text/TwilioTextProvider.ts
@@ -52,8 +52,8 @@ export default class TwilioTextProvider extends TextProvider {
 
     loadSetup(app: App): ProviderSetupMeta[] {
         return [{
-            name: 'Unsubscribe URL',
-            value: `${app.env.apiBaseUrl}/providers/${encodeHashid(this.id)}/${(this.constructor as any).namespace}/unsubscribe`,
+            name: 'Inbound URL',
+            value: `${app.env.apiBaseUrl}/providers/${encodeHashid(this.id)}/${(this.constructor as any).namespace}/inbound`,
         }]
     }
 
@@ -103,6 +103,6 @@ export default class TwilioTextProvider extends TextProvider {
 
     static controllers(): ProviderControllers {
         const admin = createController('text', this)
-        return { admin, public: this.unsubscribe(this.namespace) }
+        return { admin, public: this.inbound(this.namespace) }
     }
 }

--- a/apps/platform/src/subscriptions/SubscriptionController.ts
+++ b/apps/platform/src/subscriptions/SubscriptionController.ts
@@ -290,7 +290,6 @@ export const subscriptionUpdateSchema: JSONSchemaType<SubscriptionUpdateParams> 
     additionalProperties: false,
 }
 router.patch('/:subscriptionId', async ctx => {
-    console.log('got here?')
     const payload = validate(subscriptionUpdateSchema, ctx.request.body)
     ctx.body = await updateSubscription(ctx.state.subscription!.id, payload)
 })

--- a/apps/platform/src/subscriptions/SubscriptionService.ts
+++ b/apps/platform/src/subscriptions/SubscriptionService.ts
@@ -1,10 +1,9 @@
-import { TextProvider } from '../providers/text/TextProvider'
 import { ChannelType } from '../config/channels'
 import { PageParams } from '../core/searchParams'
 import { paramsToEncodedLink, TrackedLinkParams } from '../render/LinkService'
 import { User } from '../users/User'
 import { createEvent } from '../users/UserEventRepository'
-import { getUser, getUserFromPhone } from '../users/UserRepository'
+import { getUser } from '../users/UserRepository'
 import Subscription, { SubscriptionParams, SubscriptionState, UserSubscription } from './Subscription'
 import App from '../app'
 import { combineURLs, encodeHashid } from '../utilities'
@@ -69,22 +68,10 @@ export const subscriptionForChannel = async (channel: ChannelType, projectId: nu
     return await Subscription.first(qb => qb.where('channel', channel).where('project_id', projectId))
 }
 
-export const unsubscribeSms = async (provider: TextProvider, body: Record<string, any>) => {
-
-    const message = provider.parseInbound(body)
-
-    // Get project ID from the matched channel
-    const projectId = provider.project_id
-
-    // Check if the message includes the word STOP
-    if (message.text.toLowerCase().includes('stop')) {
-
-        // Unsubscribe the user based on inbound SMS
-        const user = await getUserFromPhone(projectId, message.from)
-        const subscription = await subscriptionForChannel('text', projectId)
-        if (user && subscription) {
-            unsubscribe(user.id, subscription.id)
-        }
+export const unsubscribeSms = async (projectId: number, user: User) => {
+    const subscription = await subscriptionForChannel('text', projectId)
+    if (user && subscription) {
+        unsubscribe(user.id, subscription.id)
     }
 }
 

--- a/apps/ui/public/locales/en.json
+++ b/apps/ui/public/locales/en.json
@@ -257,6 +257,8 @@
     "sign_out": "Sign Out",
     "sms_opt_out_message": "SMS Opt Out Message",
     "sms_opt_out_message_subtitle": "Instructions on how to opt out of SMS that will be appended to every text.",
+    "sms_help_message": "SMS Help Message",
+    "sms_help_message_subtitle": "Instructions on how to receive help that are auto sent to users if they reply with HELP.",
     "start_journey": "Start journey: ",
     "state": "State",
     "static": "Static",

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -169,7 +169,8 @@ export interface Project {
     description?: string
     locale: string
     timezone: string
-    text_opt_out_message: string
+    text_opt_out_message?: string
+    text_help_message?: string
     link_wrap: boolean
     created_at: string
     updated_at: string

--- a/apps/ui/src/ui/CodeExample.tsx
+++ b/apps/ui/src/ui/CodeExample.tsx
@@ -15,7 +15,6 @@ export default function CodeExample({ code, description, title }: CodeExamplePro
 
     const handleCopy = async (value: string) => {
         await navigator.clipboard.writeText(value)
-        console.log('copied')
         toast.success('Copied code sample')
     }
 

--- a/apps/ui/src/views/project/ProjectForm.tsx
+++ b/apps/ui/src/views/project/ProjectForm.tsx
@@ -49,9 +49,9 @@ export default function ProjectForm({ project, onSave }: ProjectFormProps) {
     return (
         <FormWrapper<Project>
             defaultValues={defaults}
-            onSubmit={async ({ id, name, description, locale, timezone, text_opt_out_message, link_wrap }) => {
+            onSubmit={async ({ id, name, description, locale, timezone, text_opt_out_message, text_help_message, link_wrap }) => {
 
-                const params = { name, description, locale, timezone, text_opt_out_message, link_wrap }
+                const params = { name, description, locale, timezone, text_opt_out_message, text_help_message, link_wrap }
 
                 const project = id
                     ? await api.projects.update(id, params)
@@ -85,6 +85,11 @@ export default function ProjectForm({ project, onSave }: ProjectFormProps) {
                             name="text_opt_out_message"
                             label={t('sms_opt_out_message')}
                             subtitle={t('sms_opt_out_message_subtitle')} />
+                        <TextInput.Field
+                            form={form}
+                            name="text_help_message"
+                            label={t('sms_help_message')}
+                            subtitle={t('sms_help_message_subtitle')} />
                         <SwitchField
                             form={form}
                             name="link_wrap"

--- a/docs/docs/providers/twilio.md
+++ b/docs/docs/providers/twilio.md
@@ -19,13 +19,13 @@ If you already have a phone number, jump to step four.
 You are now setup to send SMS messages using Twilio. There is one more step however to make it fully functioning and that is to setup inbound messages so that Parcelvoy is notified of unsubscribes.
 
 ## Inbound
-By default Twilio automatically manages [opt-outs (unsubscribes)](https://support.twilio.com/hc/en-us/articles/360034798533-Getting-Started-with-Advanced-Opt-Out-for-Messaging-Services), you just have to listen for the inbound webhook to then register that event in Parcelvoy.
+Setting up inbound messaging is important to comply with carrier rules and regulations regarding unsubscribing from communications. By default Twilio automatically manages [opt-outs (unsubscribes)](https://support.twilio.com/hc/en-us/articles/360034798533-Getting-Started-with-Advanced-Opt-Out-for-Messaging-Services), you just have to listen for the inbound webhook to then register that event in Parcelvoy. An additional benefit to setting up inbound messaging is that you can use the created events to trigger journeys.
 
 To setup inbound SMS for Twilio, do the following:
 1. In Twilip, navigate to `Develop -> Phone Numbers -> Manage -> Active Numbers`.
 2. Pick the phone number you are using internally.
 3. Scroll down to the `Messaging` section.
-4. On the line item `A Message Comes In` set the type to `Webhook`, the method to `HTTP POST` and then copy the Unsubscribe URL from your provider into that field.
+4. On the line item `A Message Comes In` set the type to `Webhook`, the method to `HTTP POST` and then copy the Inbound URL from your provider into that field.
 5. Save the values.
 
 Inbound Twilio notifications are now configured and unsubscribe events will register as Parcelvoy user events.


### PR DESCRIPTION
- Allows for triggering journeys based on inbound SMS. Inbound messages will create an event `text_inbound` containing the message that can be used to run logic on
- Adds pre-built help functionality required by SMS short codes