### PR TITLE
Fix/link wrap

### DIFF
--- a/apps/platform/src/render/LinkService.ts
+++ b/apps/platform/src/render/LinkService.ts
@@ -64,7 +64,7 @@ export const encodedLinkToParts = async (link: string | URL): Promise<TrackedLin
 }
 
 export const clickWrapHtml = (html: string, params: TrackedLinkParams) => {
-    const regex = /a.*href\s*=\s*(['"])(https?:\/\/.+?)\1/gi
+    const regex = /a.*\s*href\s*=\s*(['"])(https?:\/\/.+?)\1/gi
     let link
 
     while ((link = regex.exec(html)) !== null) {


### PR DESCRIPTION
Fixed regex for link wrapping.
It was not working as expected with the string example below:
![Screenshot 2024-07-26 at 16 18 34](https://github.com/user-attachments/assets/dbeabf5f-3cb8-4e46-bbe7-325f398af159)

I've added the `\s*` part to get spaces and newline to work.