### PR TITLE
Fixes Message SQS DelaySeconds

### DIFF
--- a/apps/platform/src/queue/SQSQueueProvider.ts
+++ b/apps/platform/src/queue/SQSQueueProvider.ts
@@ -65,7 +65,10 @@ export default class SQSQueueProvider implements QueueProvider {
     }
 
     async delay(job: Job, milliseconds: number): Promise<void> {
-        job.options.delay = milliseconds
+        // SQS Delay is in seconds, so convert milliseconds to seconds
+        // also, max delay is 15 minutes
+        const seconds = Math.min(Math.floor(milliseconds / 1000), 900)
+        job.options.delay = seconds
         await this.enqueue(job)
     }
 


### PR DESCRIPTION
This fixes the Message SQS Queue Provider. "DelaySeconds" was being sent in milliseconds, however AWS SQS accepts seconds (and 900 is the maximum).

Screenshot of the error from worker below:

![Screenshot 2024-08-01 at 16 35 47](https://github.com/user-attachments/assets/f8f373bf-01da-4724-8e9b-ac388b63cacc)
