### PR TITLE
Added rate interval on provider

### DIFF
--- a/apps/platform/db/migrations/20240808205738_add_provider_rate_interval.js
+++ b/apps/platform/db/migrations/20240808205738_add_provider_rate_interval.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+    await knex.schema.table('providers', function(table) {
+        table.string('rate_interval', 12).defaultTo('second').after('rate_limit')
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('providers', function(table) {
+        table.dropColumn('rate_interval')
+    })
+}

--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -36,6 +36,7 @@ describe('CampaignService', () => {
             name: uuid(),
             is_default: false,
             rate_limit: 10,
+            rate_interval: 'second',
         })
         return {
             project_id: project.id,

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -152,6 +152,7 @@ export const throttleSend = async (channel: Channel, points = 1): Promise<RateLi
         {
             limit: provider.rate_limit,
             points,
+            msDuration: provider.interval(),
         },
     )
 }

--- a/apps/platform/src/providers/Provider.ts
+++ b/apps/platform/src/providers/Provider.ts
@@ -41,7 +41,11 @@ export function ProviderSchema<_ extends ExternalProviderParams, D>(id: string, 
             data,
             rate_limit: {
                 type: 'number',
-                description: 'The per second maximum send rate.',
+                description: 'The per interval maximum send rate.',
+                nullable: true,
+            },
+            rate_interval: {
+                type: 'string',
                 nullable: true,
             },
         },
@@ -57,6 +61,7 @@ export default class Provider extends Model {
     data!: Record<string, any>
     is_default!: boolean
     rate_limit!: number
+    rate_interval!: 'second' | 'minute' | 'hour' | 'day'
     setup!: ProviderSetupMeta[]
 
     static jsonAttributes = ['data']
@@ -103,6 +108,16 @@ export default class Provider extends Model {
     }
 
     static get options(): ProviderOptions { return {} }
+
+    interval() {
+        const intervals = {
+            second: 1000,
+            minute: 60 * 1000,
+            hour: 60 * 60 * 1000,
+            day: 24 * 60 * 60 * 1000,
+        }
+        return intervals[this.rate_interval || 'second']
+    }
 }
 
 export type ProviderMap<T extends Provider> = (record: any) => T

--- a/apps/ui/public/locales/en.json
+++ b/apps/ui/public/locales/en.json
@@ -211,6 +211,7 @@
     "publish": "Publish",
     "published": "Published",
     "push": "Push",
+    "rate_interval": "Rate Interval",
     "rate_limit": "Rate Limit",
     "raw_json": "Raw JSON",
     "ready": "Ready",

--- a/apps/ui/public/locales/es.json
+++ b/apps/ui/public/locales/es.json
@@ -211,6 +211,7 @@
     "publish": "Publicar",
     "published": "Publicado",
     "push": "Notificación",
+    "rate_interval": "Intervalo de Velocidad",
     "rate_limit": "Límite de Velocidad",
     "raw_json": "JSON Sin Procesar",
     "ready": "Listo",

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -502,10 +502,11 @@ export interface Provider {
     group: string
     data: any
     rate_limit: number
+    rate_interval: string
     setup: ProviderSetupMeta[]
 }
 
-export type ProviderCreateParams = Pick<Provider, 'name' | 'data' | 'type' | 'group' | 'rate_limit'>
+export type ProviderCreateParams = Pick<Provider, 'name' | 'data' | 'type' | 'group' | 'rate_limit' | 'rate_interval'>
 export type ProviderUpdateParams = ProviderCreateParams
 export interface ProviderMeta {
     name: string

--- a/apps/ui/src/views/settings/IntegrationModal.tsx
+++ b/apps/ui/src/views/settings/IntegrationModal.tsx
@@ -7,12 +7,14 @@ import Alert from '../../ui/Alert'
 import Button from '../../ui/Button'
 import SchemaFields from '../../ui/form/SchemaFields'
 import TextInput from '../../ui/form/TextInput'
+import RadioInput from '../../ui/form/RadioInput'
 import FormWrapper from '../../ui/form/FormWrapper'
 import Modal, { ModalProps } from '../../ui/Modal'
 import Tile, { TileGrid } from '../../ui/Tile'
 import { snakeToTitle } from '../../utils'
 import './IntegrationModal.css'
 import { ChevronLeftIcon } from '../../ui/icons'
+import { useTranslation } from 'react-i18next'
 
 interface IntegrationFormParams {
     project: Project
@@ -22,6 +24,7 @@ interface IntegrationFormParams {
 }
 
 export function IntegrationForm({ project, provider: defaultProvider, onChange, meta }: IntegrationFormParams) {
+    const { t } = useTranslation()
     const [provider, setProvider] = useState<Provider | undefined>(defaultProvider)
     const { type, group } = meta
     useEffect(() => {
@@ -34,9 +37,9 @@ export function IntegrationForm({ project, provider: defaultProvider, onChange, 
         }
     }, [defaultProvider])
 
-    async function handleCreate({ name, rate_limit, data = {} }: ProviderCreateParams | ProviderUpdateParams) {
+    async function handleCreate({ name, rate_limit, rate_interval, data = {} }: ProviderCreateParams | ProviderUpdateParams) {
 
-        const params = { name, data, rate_limit, type, group }
+        const params = { name, data, rate_limit, rate_interval, type, group }
         const value = provider?.id
             ? await api.providers.update(project.id, provider?.id, params)
             : await api.providers.create(project.id, params)
@@ -74,7 +77,18 @@ export function IntegrationForm({ project, provider: defaultProvider, onChange, 
                         form={form}
                         type="number"
                         name="rate_limit"
-                        subtitle="If you need to cap send rate, enter the maximum per second limit." />
+                        subtitle="If you need to cap send rate, enter the maximum per interval limit." />
+                    <RadioInput.Field
+                        form={form}
+                        name="rate_interval"
+                        label={t('rate_interval')}
+                        options={[
+                            { key: 'second', label: 'second' },
+                            { key: 'minute', label: 'minute' },
+                            { key: 'hour', label: 'hour' },
+                            { key: 'day', label: 'day' },
+                        ]}
+                    />
                 </>
             }
         </FormWrapper>

--- a/apps/ui/src/views/settings/IntegrationModal.tsx
+++ b/apps/ui/src/views/settings/IntegrationModal.tsx
@@ -83,10 +83,10 @@ export function IntegrationForm({ project, provider: defaultProvider, onChange, 
                         name="rate_interval"
                         label={t('rate_interval')}
                         options={[
-                            { key: 'second', label: 'second' },
-                            { key: 'minute', label: 'minute' },
-                            { key: 'hour', label: 'hour' },
-                            { key: 'day', label: 'day' },
+                            { key: 'second', label: t('second') },
+                            { key: 'minute', label: t('minute') },
+                            { key: 'hour', label: t('hour') },
+                            { key: 'day', label: t('day') },
                         ]}
                     />
                 </>


### PR DESCRIPTION
This implements a rate interval when creating a Provider. Before the interval was fixed at 'second' rate and the slowest rate was 1 per second.

With this PR, it is possible to send campaigns on 1 per minute rate, 1 per hour, etc.

I've tested on 1 per minute and 1 per hour, both worked flawlessly.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/4ab41996-2ec3-4e78-890c-8d5ac24bbb69">
