### PR TITLE
Better handle if dataset has a fullname value

### DIFF
--- a/apps/platform/src/users/User.ts
+++ b/apps/platform/src/users/User.ts
@@ -62,6 +62,11 @@ export class User extends Model {
     }
 
     get fullName() {
+        // Handle case were user has a full name attribute in data
+        const fullName = this.data.full_name ?? this.data.fullName
+        if (fullName) return fullName
+
+        // If no attribute exists, combine first and last name
         const parts: string[] = []
         if (this.firstName) {
             parts.push(this.firstName)


### PR DESCRIPTION
For situations where the dataset has a variable with the full name value, default to that instead