### PR TITLE
Allows for additional OpenID response types

### DIFF
--- a/apps/platform/src/auth/GoogleAuthProvider.ts
+++ b/apps/platform/src/auth/GoogleAuthProvider.ts
@@ -18,6 +18,7 @@ export default class GoogleAuthProvider extends AuthProvider {
             ...config,
             driver: 'openid',
             issuerUrl: 'https://accounts.google.com',
+            responseTypes: ['id_token'],
         })
     }
 

--- a/apps/platform/src/auth/OpenIDAuthProvider.ts
+++ b/apps/platform/src/auth/OpenIDAuthProvider.ts
@@ -14,6 +14,7 @@ export interface OpenIDConfig extends AuthTypeConfig {
     clientSecret: string
     redirectUri: string
     domain?: string
+    responseTypes: string[]
 }
 
 export default class OpenIDAuthProvider extends AuthProvider {
@@ -115,7 +116,7 @@ export default class OpenIDAuthProvider extends AuthProvider {
             client_id: this.config.clientId,
             client_secret: this.config.clientSecret,
             redirect_uris: [this.config.redirectUri],
-            response_types: ['id_token'],
+            response_types: this.config.responseTypes ?? ['id_token'],
         })
         return this.client
     }

--- a/apps/platform/src/config/env.ts
+++ b/apps/platform/src/config/env.ts
@@ -148,6 +148,7 @@ export default (type?: EnvType): Env => {
                 clientSecret: process.env.AUTH_OPENID_CLIENT_SECRET!,
                 redirectUri: `${apiBaseUrl}/auth/login/openid/callback`,
                 domain: process.env.AUTH_OPENID_DOMAIN!,
+                responseTypes: process.env.AUTH_OPENID_RESPONSE_TYPES?.split(',') ?? ['id_token'],
             },
             google: {
                 driver: 'google',

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -29,6 +29,7 @@ AUTH_BASIC_PASSWORD=password
 | AUTH_OPENID_CLIENT_SECRET | string | true |
 | AUTH_OPENID_REDIRECT_URI | string | true |
 | AUTH_OPENID_DOMAIN_WHITELIST | string | true |
+| AUTH_OPENID_RESPONSE_TYPES | string | false |
 
 ## SAML
 


### PR DESCRIPTION
Currently only `id_token` is supported, based on feedback in #487, this set of changes allows for passing in custom types based on what the OpenID provider supports.