### PR TITLE
Have subscription status events trigger journeys

### DIFF
--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -123,6 +123,7 @@ export const createUser = async (projectId: number, { external_id, anonymous_id,
     // Create an event for the user creation
     await EventPostJob.from({
         project_id: projectId,
+        user_id: user.id,
         event: {
             name: 'user_created',
             external_id: user.external_id,


### PR DESCRIPTION
Subscription status events were never updated to trigger journey logic after we updated journey entrance types. This brings them in line with how we handle `user_created` events

Fixes #512