### PR TITLE
Adds logic to perpetually keep a send list up to date

### DIFF
--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -2,11 +2,11 @@ import App from '../../app'
 import EmailJob from '../../providers/email/EmailJob'
 import { RequestError } from '../../core/errors'
 import { addUserToList, createList } from '../../lists/ListService'
-import { createSubscription, subscribe } from '../../subscriptions/SubscriptionService'
+import { createSubscription, subscribe, subscribeAll } from '../../subscriptions/SubscriptionService'
 import { User } from '../../users/User'
 import { uuid } from '../../utilities'
 import Campaign, { CampaignSend, SentCampaign } from '../Campaign'
-import { allCampaigns, createCampaign, getCampaign, sendCampaign, generateSendList, estimatedSendSize } from '../CampaignService'
+import { allCampaigns, createCampaign, getCampaign, sendCampaign, generateSendList, estimatedSendSize, updateCampaignSendEnrollment } from '../CampaignService'
 import { createProvider } from '../../providers/ProviderRepository'
 import { createTestProject } from '../../projects/__tests__/ProjectTestHelpers'
 import ListStatsJob from '../../lists/ListStatsJob'
@@ -272,6 +272,77 @@ describe('CampaignService', () => {
 
             const sendSize = await estimatedSendSize(campaign)
             expect(sendSize).toEqual(40)
+        })
+    })
+
+    describe('updateCampaignSendEnrollment', () => {
+        test('join a user to a scheduled campaign', async () => {
+            const params = await createCampaignDependencies()
+            const list = await createList(params.project_id, {
+                name: uuid(),
+                type: 'static',
+                is_visible: true,
+            })
+            const campaign = await createTestCampaign(params, {
+                list_ids: [list.id],
+            }) as SentCampaign
+            await Campaign.updateAndFetch(campaign.id, { state: 'scheduled' })
+
+            const user = await createUser(campaign.project_id)
+            await subscribeAll(user)
+            await addUserToList(user, list)
+
+            await updateCampaignSendEnrollment(user)
+
+            const updated = await CampaignSend.first(qb => qb.where('campaign_id', campaign.id).where('user_id', user.id))
+
+            expect(updated).not.toBeUndefined()
+        })
+
+        test('do not join a user to a draft campaign', async () => {
+            const params = await createCampaignDependencies()
+            const list = await createList(params.project_id, {
+                name: uuid(),
+                type: 'static',
+                is_visible: true,
+            })
+            const campaign = await createTestCampaign(params, {
+                list_ids: [list.id],
+            }) as SentCampaign
+
+            const user = await createUser(campaign.project_id)
+            await subscribeAll(user)
+            await addUserToList(user, list)
+
+            await updateCampaignSendEnrollment(user)
+
+            const updated = await CampaignSend.first(qb => qb.where('campaign_id', campaign.id).where('user_id', user.id))
+
+            expect(updated).toBeUndefined()
+        })
+
+        test('remove a user who no longer matches list', async () => {
+            const params = await createCampaignDependencies()
+            const list = await createList(params.project_id, {
+                name: uuid(),
+                type: 'static',
+                is_visible: true,
+            })
+            const campaign = await createTestCampaign(params, {
+                list_ids: [list.id],
+            }) as SentCampaign
+            await Campaign.updateAndFetch(campaign.id, { state: 'scheduled' })
+
+            const user = await createUser(campaign.project_id)
+            await subscribeAll(user)
+
+            await CampaignSend.insert({ campaign_id: campaign.id, user_id: user.id, state: 'pending' })
+
+            await updateCampaignSendEnrollment(user)
+
+            const updated = await CampaignSend.first(qb => qb.where('campaign_id', campaign.id).where('user_id', user.id))
+
+            expect(updated).toBeUndefined()
         })
     })
 })

--- a/apps/platform/src/providers/Provider.ts
+++ b/apps/platform/src/providers/Provider.ts
@@ -122,7 +122,7 @@ export default class Provider extends Model {
 
 export type ProviderMap<T extends Provider> = (record: any) => T
 
-export type ProviderParams = Omit<Provider, ModelParams | 'setup' | 'loadSetup'>
+export type ProviderParams = Omit<Provider, ModelParams | 'setup' | 'loadSetup' | 'interval'>
 
 export type ExternalProviderParams = Omit<ProviderParams, 'group'>
 


### PR DESCRIPTION
Currently after you create a campaign it does not update the user the list will be going to even if you schedule the campaign for way in the future. The initial rationale behind this is that generating a send is expensive and it's hard to know when to cutoff a list since you could be sending to a disparate group of timezones.

This logic piggybacks off of the performance improvements introduced by rule caching to check for list additions and removals to know if we should re-check a users enrollment in a campaign. If the campaign has not yet started running and a users enrollment changes, we want to reflect that in the campaign by either adding or removing the user from the send. This should at best get you granularity up until the minute before a send and at worst up to 24hrs off depending on the timezone of the user and the other users you are sending to.