### PR TITLE
Fixes list count drifting over time

### DIFF
--- a/apps/platform/db/migrations/20241017002221_reset_list_totals.js
+++ b/apps/platform/db/migrations/20241017002221_reset_list_totals.js
@@ -1,0 +1,7 @@
+exports.up = async function(knex) {
+    await knex('lists').update({ users_count: null })
+}
+
+exports.down = async function(knex) {
+    await knex('lists').update({ users_count: null })
+}

--- a/apps/platform/src/config/redis.ts
+++ b/apps/platform/src/config/redis.ts
@@ -30,4 +30,22 @@ export const cacheSet = async <T>(redis: Redis, key: string, value: T, ttl?: num
     }
 }
 
+export const cacheDel = async (redis: Redis, key: string) => {
+    return await redis.del(key)
+}
+
+export const cacheIncr = async (redis: Redis, key: string, incr = 1, ttl?: number) => {
+    await redis.incrby(key, incr)
+    if (ttl) {
+        await redis.expire(key, ttl)
+    }
+}
+
+export const cacheDecr = async (redis: Redis, key: string, ttl?: number) => {
+    await redis.decr(key)
+    if (ttl) {
+        await redis.expire(key, ttl)
+    }
+}
+
 export { Redis }

--- a/apps/platform/src/lists/ListPopulateJob.ts
+++ b/apps/platform/src/lists/ListPopulateJob.ts
@@ -22,6 +22,6 @@ export default class ListPopulateJob extends Job {
 
         await populateList(list)
 
-        await ListStatsJob.from(listId, projectId).queue()
+        await ListStatsJob.from(listId, projectId, true).queue()
     }
 }

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -158,7 +158,7 @@ export const countKey = (list: List) => `list:${list.id}:${list.version}:count`
 
 export const addUserToList = async (user: User | number, list: List, event?: UserEvent) => {
     const userId = user instanceof User ? user.id : user
-    const count = await UserList.query()
+    const resp = await UserList.query()
         .insert({
             user_id: userId,
             list_id: list.id,
@@ -167,8 +167,8 @@ export const addUserToList = async (user: User | number, list: List, event?: Use
         })
         .onConflict(['user_id', 'list_id'])
         .ignore()
-    if (count) cacheIncr(App.main.redis, countKey(list))
-    return count
+    if (resp?.[0]) await cacheIncr(App.main.redis, countKey(list))
+    return resp
 }
 
 export const removeUserFromList = async (user: User | number, list: List) => {
@@ -177,7 +177,7 @@ export const removeUserFromList = async (user: User | number, list: List) => {
         qb.where('user_id', userId)
             .where('list_id', list.id),
     )
-    if (count) cacheDecr(App.main.redis, countKey(list))
+    if (count) await cacheDecr(App.main.redis, countKey(list))
     return count
 }
 

--- a/apps/platform/src/lists/ListStatsJob.ts
+++ b/apps/platform/src/lists/ListStatsJob.ts
@@ -30,7 +30,7 @@ export default class ListStatsJob extends Job {
 
         let count = await cacheGet<number>(redis, cacheKey) ?? 0
         if (!list?.users_count || reset) {
-            cacheDel(redis, cacheKey)
+            await cacheDel(redis, cacheKey)
             count = await listUserCount(listId)
             await cacheIncr(redis, cacheKey, count)
         }

--- a/apps/platform/src/lists/__tests__/ListService.spec.ts
+++ b/apps/platform/src/lists/__tests__/ListService.spec.ts
@@ -5,7 +5,7 @@ import { RuleTree } from '../../rules/Rule'
 import { User } from '../../users/User'
 import { UserEvent } from '../../users/UserEvent'
 import { random, randomInt, uuid } from '../../utilities'
-import List, { UserList } from '../List'
+import { UserList } from '../List'
 import { addUserToList, countKey, createList, listsForRule, populateList, removeUserFromList, updateList } from '../ListService'
 
 describe('ListService', () => {


### PR DESCRIPTION
Currently the list count has a fundamental flaw in that its not decrementing the total whenever a user is removed from a list so over time it just continues to drift upward.

This completely removes partial counting from the list totals equation and instead relies on redis key incrementing and decrementing to keep track of totals and then periodically pulls those values into the database. This removes the counting load almost completely from the database.

It also fixes re-counting when updating a ruleset for a list.

This does temporarily reset the count of every list to zero so that they can be recalculated accurate to start the new incrementing system.