### PR TITLE
Force casting of send at value

### DIFF
--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -36,7 +36,7 @@ export default class Campaign extends Model {
     tags?: string[]
 
     send_in_user_timezone?: boolean
-    send_at?: string | Date
+    send_at?: string | Date | null
 
     deleted_at?: Date
 

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -111,17 +111,18 @@ export const updateCampaign = async (id: number, projectId: number, { tags, ...p
     }
 
     const data: Partial<Campaign> = { ...params }
+    let send_at: Date | undefined | null = data.send_at ? new Date(data.send_at) : undefined
 
     // If we are aborting, reset `send_at`
     if (data.state === 'aborted') {
-        data.send_at = undefined
+        send_at = null
         await abortCampaign(campaign)
     }
 
     // If we are rescheduling, abort sends so they are reset
-    if (data.send_at
+    if (send_at
         && campaign.send_at
-        && data.send_at !== campaign.send_at) {
+        && send_at !== campaign.send_at) {
         data.state = 'pending'
         await abortCampaign(campaign)
     }
@@ -141,6 +142,7 @@ export const updateCampaign = async (id: number, projectId: number, { tags, ...p
 
     await Campaign.update(qb => qb.where('id', id), {
         ...data,
+        send_at,
     })
 
     if (tags) {


### PR DESCRIPTION
It seems like some browsers aren't properly formatting dates such that the DB isn't happy, this forces the `send_at` date for campaigns to be parsed as a JS date before insertion into the DB