### PR TITLE
Correct required docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
   mysql:
     image: mysql:8.0.36


### PR DESCRIPTION
The `healthcheck.start_period` attribute was introduced in Docker Compose 3.4