### PR TITLE
Improve campaign send performance

### DIFF
--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -6,7 +6,7 @@ import { createSubscription, subscribe, subscribeAll } from '../../subscriptions
 import { User } from '../../users/User'
 import { uuid } from '../../utilities'
 import Campaign, { CampaignSend, SentCampaign } from '../Campaign'
-import { allCampaigns, createCampaign, getCampaign, sendCampaign, generateSendList, estimatedSendSize, updateCampaignSendEnrollment } from '../CampaignService'
+import { allCampaigns, createCampaign, getCampaign, generateSendList, estimatedSendSize, updateCampaignSendEnrollment } from '../CampaignService'
 import { createProvider } from '../../providers/ProviderRepository'
 import { createTestProject } from '../../projects/__tests__/ProjectTestHelpers'
 import ListStatsJob from '../../lists/ListStatsJob'
@@ -152,20 +152,6 @@ describe('CampaignService', () => {
                 name,
             })
             await expect(promise).rejects.toThrowError(RequestError)
-        })
-    })
-
-    describe('sendCampaign', () => {
-        test('enqueue an email job', async () => {
-
-            const campaign = await createTestCampaign()
-            const user = await createUser(campaign.project_id)
-
-            const spy = jest.spyOn(App.main.queue, 'enqueue')
-            await sendCampaign({ campaign, user })
-
-            expect(spy).toHaveBeenCalledTimes(1)
-            expect(spy.mock.calls[0][0]).toBeInstanceOf(EmailJob)
         })
     })
 

--- a/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
+++ b/apps/platform/src/campaigns/__tests__/CampaignService.spec.ts
@@ -1,5 +1,3 @@
-import App from '../../app'
-import EmailJob from '../../providers/email/EmailJob'
 import { RequestError } from '../../core/errors'
 import { addUserToList, createList } from '../../lists/ListService'
 import { createSubscription, subscribe, subscribeAll } from '../../subscriptions/SubscriptionService'

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -152,7 +152,7 @@ export const throttleSend = async (channel: Channel, points = 1): Promise<RateLi
         {
             limit: provider.rate_limit,
             points,
-            msDuration: provider.interval(),
+            msDuration: provider.interval,
         },
     )
 }

--- a/apps/platform/src/providers/Provider.ts
+++ b/apps/platform/src/providers/Provider.ts
@@ -134,7 +134,7 @@ export default class Provider extends Model {
 
 export type ProviderMap<T extends Provider> = (record: any) => T
 
-export type ProviderParams = Omit<Provider, ModelParams | 'setup' | 'loadSetup' | 'interval'>
+export type ProviderParams = Omit<Provider, ModelParams | 'setup' | 'loadSetup' | 'interval' | 'ratePer'>
 
 export type ExternalProviderParams = Omit<ProviderParams, 'group'>
 

--- a/apps/platform/src/providers/Provider.ts
+++ b/apps/platform/src/providers/Provider.ts
@@ -53,6 +53,8 @@ export function ProviderSchema<_ extends ExternalProviderParams, D>(id: string, 
     } as any
 }
 
+type RateInterval = 'second' | 'minute' | 'hour' | 'day'
+
 export default class Provider extends Model {
     type!: string
     name!: string
@@ -61,7 +63,7 @@ export default class Provider extends Model {
     data!: Record<string, any>
     is_default!: boolean
     rate_limit!: number
-    rate_interval!: 'second' | 'minute' | 'hour' | 'day'
+    rate_interval!: RateInterval
     setup!: ProviderSetupMeta[]
 
     static jsonAttributes = ['data']
@@ -109,7 +111,7 @@ export default class Provider extends Model {
 
     static get options(): ProviderOptions { return {} }
 
-    interval() {
+    get interval() {
         const intervals = {
             second: 1000,
             minute: 60 * 1000,
@@ -117,6 +119,16 @@ export default class Provider extends Model {
             day: 24 * 60 * 60 * 1000,
         }
         return intervals[this.rate_interval || 'second']
+    }
+
+    ratePer(period: RateInterval) {
+        const intervals = {
+            second: 1,
+            minute: 60,
+            hour: 60 * 60,
+            day: 24 * 60 * 60,
+        }
+        return this.rate_limit * intervals[period]
     }
 }
 


### PR DESCRIPTION
- Reduce Redis memory usage by only enqueuing the most jobs that are possible over a given rate limit
- Allow for recovery of throttled jobs in the case of Redis running out of memory by re-adding them to the queue just like pending jobs