### PR TITLE
added check unsubscribe om emailjob handler

### DIFF
--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -221,6 +221,7 @@ export const sendCampaignJob = ({ campaign, user, event, send_id, reference_type
 
     // TODO: Might also need to check for unsubscribe in here since we can
     // do individual sends
+    // Added a check for unsubscribed in EmailJob handler
     const body = {
         campaign_id: campaign.id,
         user_id: user instanceof User ? user.id : user,

--- a/apps/platform/src/providers/email/EmailJob.ts
+++ b/apps/platform/src/providers/email/EmailJob.ts
@@ -7,6 +7,8 @@ import { EmailTemplate } from '../../render/Template'
 import { EncodedJob } from '../../queue'
 import App from '../../app'
 import { releaseLock } from '../../core/Lock'
+import { getUserSubscriptionState } from '../../subscriptions/SubscriptionService'
+import { SubscriptionState } from '../../subscriptions/Subscription'
 
 export default class EmailJob extends Job {
     static $name = 'email'
@@ -39,6 +41,9 @@ export default class EmailJob extends Job {
         if (!isReady) return
 
         try {
+            const subscriptionState = await getUserSubscriptionState(user.id, campaign.subscription_id)
+            if (subscriptionState === SubscriptionState.unsubscribed) throw new Error('User is unsubscribed')
+
             const result = await channel.send(template, data)
             await finalizeSend(data, result)
         } catch (error: any) {


### PR DESCRIPTION
We noticed that sometimes users were receiving emails after unsubscribe event

<img width="829" alt="image" src="https://github.com/user-attachments/assets/1faa22d3-4360-4034-b1eb-8ec286124b99">

I also noticed, @pushchris, that on CampaignService.ts, on sendCampaignJob function, this comment:
![image](https://github.com/user-attachments/assets/4ab851d6-10e1-4411-8bc7-db2ed28133c2)

I tried to put the unsubscribe check there, but since it's expecting a EmailJob, I could not (I could throw an Error there, but I don't know how it would behave)

So, I ended up putting on the EmailJob handler, since it already have a catch that fires the failSend.

Does it makes sense?