### PR TITLE
Automatic List Regeneration When Using Relative Date Rules

### DIFF
--- a/apps/platform/db/migrations/20241109235323_add_list_refreshed_at.js
+++ b/apps/platform/db/migrations/20241109235323_add_list_refreshed_at.js
@@ -1,0 +1,23 @@
+exports.up = async function(knex) {
+    await knex.schema.table('lists', function(table) {
+        table.timestamp('refreshed_at')
+    })
+
+    const lists = await knex('rules')
+        .leftJoin('rules as parent_rules', 'rules.root_uuid', 'parent_rules.uuid')
+        .leftJoin('lists', 'lists.rule_id', 'parent_rules.id')
+        .where('rules.type', 'date')
+        .where('rules.value', 'LIKE', '%now%')
+        .where('rules.value', 'LIKE', '%{{%')
+        .groupBy('lists.id')
+        .select('lists.id')
+    await knex('lists')
+        .update('refreshed_at', knex.raw('NOW()'))
+        .whereIn('id', lists.map(list => list.id))
+}
+
+exports.down = async function(knex) {
+    await knex.schema.table('lists', function(table) {
+        table.dropColumn('refreshed_at')
+    })
+}

--- a/apps/platform/db/migrations/20241119174518_add_journey_user_step_timestamp_index.js
+++ b/apps/platform/db/migrations/20241119174518_add_journey_user_step_timestamp_index.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.index(['type', 'delay_until'])
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.dropIndex(['type', 'delay_until'])
+    })
+}

--- a/apps/platform/src/config/queue.ts
+++ b/apps/platform/src/config/queue.ts
@@ -25,6 +25,7 @@ import JourneyStatsJob from '../journey/JourneyStatsJob'
 import UpdateJourneysJob from '../journey/UpdateJourneysJob'
 import ScheduledEntranceJob from '../journey/ScheduledEntranceJob'
 import ScheduledEntranceOrchestratorJob from '../journey/ScheduledEntranceOrchestratorJob'
+import ListRefreshJob from '../lists/ListRefreshJob'
 
 export const jobs = [
     CampaignGenerateListJob,
@@ -37,6 +38,7 @@ export const jobs = [
     JourneyDelayJob,
     JourneyProcessJob,
     JourneyStatsJob,
+    ListRefreshJob,
     ListPopulateJob,
     ListStatsJob,
     ProcessListsJob,

--- a/apps/platform/src/journey/JourneyRepository.ts
+++ b/apps/platform/src/journey/JourneyRepository.ts
@@ -309,7 +309,6 @@ export const getJourneyUserStepByExternalId = async (journeyId: number, userId: 
 }
 
 export const exitUserFromJourney = async (userId: number, entranceId: number, journeyId: number) => {
-    console.log('exiting from', userId, entranceId, journeyId)
     await JourneyUserStep.update(
         q => q.where('user_id', userId)
             .where('id', entranceId)

--- a/apps/platform/src/lists/List.ts
+++ b/apps/platform/src/lists/List.ts
@@ -15,6 +15,7 @@ export default class List extends Model {
     users_count?: number
     tags?: string[]
     is_visible!: boolean
+    refreshed_at?: Date | null
     deleted_at?: Date
 }
 

--- a/apps/platform/src/lists/ListController.ts
+++ b/apps/platform/src/lists/ListController.ts
@@ -3,7 +3,7 @@ import { JSONSchemaType, validate } from '../core/validate'
 import { extractQueryParams } from '../utilities'
 import List, { ListCreateParams, ListUpdateParams } from './List'
 import { archiveList, createList, deleteList, getList, getListUsers, importUsersToList, pagedLists, updateList } from './ListService'
-import { searchParamsSchema } from '../core/searchParams'
+import { SearchSchema } from '../core/searchParams'
 import { ProjectState } from '../auth/AuthMiddleware'
 import parse from '../storage/FileStream'
 import { projectRoleMiddleware } from '../projects/ProjectService'
@@ -17,7 +17,11 @@ const router = new Router<
 router.use(projectRoleMiddleware('editor'))
 
 router.get('/', async ctx => {
-    const params = extractQueryParams(ctx.query, searchParamsSchema)
+    const searchSchema = SearchSchema('listUserSearchSchema', {
+        sort: 'id',
+        direction: 'desc',
+    })
+    const params = extractQueryParams(ctx.query, searchSchema)
     ctx.body = await pagedLists(params, ctx.state.project.id)
 })
 
@@ -177,7 +181,11 @@ router.delete('/:listId', async ctx => {
 })
 
 router.get('/:listId/users', async ctx => {
-    const params = extractQueryParams(ctx.query, searchParamsSchema)
+    const searchSchema = SearchSchema('listUserSearchSchema', {
+        sort: 'id',
+        direction: 'desc',
+    })
+    const params = extractQueryParams(ctx.query, searchSchema)
     ctx.body = await getListUsers(ctx.state.list!.id, params, ctx.state.project.id)
 })
 

--- a/apps/platform/src/lists/ListRefreshJob.ts
+++ b/apps/platform/src/lists/ListRefreshJob.ts
@@ -1,0 +1,30 @@
+import { Job } from '../queue'
+import { getDateRuleTypes } from '../rules/RuleService'
+import { getList, refreshList } from './ListService'
+
+interface ListRefreshParams {
+    listId: number
+    projectId: number
+}
+
+export default class ListRefreshJob extends Job {
+    static $name = 'list_refresh_job'
+
+    static from(
+        listId: number,
+        projectId: number,
+    ): ListRefreshJob {
+        return new this({ listId, projectId })
+    }
+
+    static async handler({ listId, projectId }: ListRefreshParams) {
+
+        const list = await getList(listId, projectId)
+        if (!list || !list.rule_id) return
+
+        const dateRuleTypes = await getDateRuleTypes(list.rule_id)
+        if (!dateRuleTypes?.dynamic) return
+
+        await refreshList(list, dateRuleTypes)
+    }
+}

--- a/apps/platform/src/lists/ListService.ts
+++ b/apps/platform/src/lists/ListService.ts
@@ -8,9 +8,9 @@ import ListPopulateJob from './ListPopulateJob'
 import { importUsers } from '../users/UserImport'
 import { FileStream } from '../storage/FileStream'
 import { createTagSubquery, getTags, setTags } from '../tags/TagService'
-import { Chunker, visit } from '../utilities'
+import { Chunker } from '../utilities'
 import { getUserEventsForRules } from '../users/UserRepository'
-import { RuleResults, RuleWithEvaluationResult, checkRules, decompileRule, fetchAndCompileRule, mergeInsertRules } from '../rules/RuleService'
+import { DateRuleTypes, RuleResults, RuleWithEvaluationResult, checkRules, decompileRule, fetchAndCompileRule, getDateRuleType, mergeInsertRules, splitRuleTree } from '../rules/RuleService'
 import { updateCampaignSendEnrollment } from '../campaigns/CampaignService'
 import { cacheDecr, cacheIncr } from '../config/redis'
 import App from '../app'
@@ -105,9 +105,18 @@ export const createList = async (projectId: number, { tags, name, type, rule }: 
         // Decompile rule into separate flat parts
         const [wrapper, ...rules] = decompileRule(rule, { project_id: projectId })
 
+        // Check if there are any date rules to start the list refresh scheduler
+        const isDynamic = rules.some(rule => getDateRuleType(rule)?.dynamic)
+        list.refreshed_at = isDynamic ? new Date() : null
+
         // Insert top level wrapper to get ID to associate
         list.rule_id = await Rule.insert(wrapper)
-        await List.update(qb => qb.where('id', list.id), { rule_id: list.rule_id })
+
+        // Update list with new settings
+        await List.update(qb => qb.where('id', list.id), {
+            rule_id: list.rule_id,
+            refreshed_at: list.refreshed_at,
+        })
 
         // Insert rest of rules
         if (rules && rules.length) {
@@ -139,7 +148,18 @@ export const updateList = async (list: List, { tags, rule, published, ...params 
     if (rule && list.type === 'dynamic') {
 
         const rules = decompileRule(rule, { project_id: list.project_id })
+
+        // Modify the rule data structure to match modifications
         await mergeInsertRules(rules)
+
+        // Check if there are any date rules to start the list refresh scheduler
+        const isDynamic = rules.some(rule => getDateRuleType(rule)?.dynamic)
+        list.refreshed_at = isDynamic ? new Date() : null
+        await List.update(qb => qb.where('id', list.id), {
+            refreshed_at: list.refreshed_at,
+        })
+
+        // Start repopulation of the list
         await ListPopulateJob.from(list.id, list.project_id).queue()
     }
 
@@ -198,14 +218,67 @@ export const importUsersToList = async (list: List, stream: FileStream) => {
     await updateListState(list.id, { state: 'ready' })
 }
 
+interface UserListEventEvaluation {
+    rule_id: number
+    user_id: number
+    result: boolean
+}
+
+interface UserListEvaluation {
+    list: List
+    scroll: AsyncGenerator<User[], any, any>
+    since?: Date | null
+    handleRule: (evaluation: UserListEventEvaluation) => Promise<void>
+    handleEntry: (user: User, result: boolean) => Promise<void>
+}
+
+const scrollUserListForEvaluation = async ({
+    list,
+    scroll,
+    since,
+    handleRule,
+    handleEntry,
+}: UserListEvaluation) => {
+    if (!list.rule_id) return
+    const rule = await fetchAndCompileRule(list.rule_id) as RuleTree
+    const { eventRules, userRules } = splitRuleTree(rule)
+
+    for await (const users of scroll) {
+
+        // For each user, evaluate parts and batch enqueue
+        for (const user of users) {
+
+            const parts: RuleWithEvaluationResult[] = []
+            const events = await getUserEventsForRules([user.id], eventRules, since)
+
+            for (const rule of eventRules) {
+                const result = check({
+                    user: user.flatten(),
+                    events: events.map(e => e.flatten()),
+                }, rule)
+                await handleRule({
+                    rule_id: rule.id!,
+                    user_id: user.id,
+                    result,
+                })
+                parts.push({
+                    ...rule,
+                    result,
+                })
+            }
+
+            const result = checkRules(user, rule, [...parts, ...userRules])
+            await handleEntry(user, result)
+        }
+    }
+}
+
 export const populateList = async (list: List) => {
-    const { id, version: oldVersion = 0, rule_id } = list
+    const { id, version: oldVersion = 0 } = list
     const version = oldVersion + 1
     await updateListState(id, { state: 'loading', version })
 
-    if (!rule_id) return
-
-    const rule = await fetchAndCompileRule(rule_id) as RuleTree
+    const scroll = User.scroll(q => q.where('project_id', list.project_id))
 
     // Collect matching user ids, insert in batches of 100
     const userChunker = new Chunker<number>(async userIds => {
@@ -231,52 +304,18 @@ export const populateList = async (list: List) => {
             .merge(['result'])
     }, 100)
 
-    // Fetch all users and iterate over them
-    const scroll = User.scroll(q => q.where('project_id', list.project_id))
-
-    const eventRules: RuleTree[] = []
-    const userRules: RuleTree[] = []
-    visit(rule, r => r.children, r => {
-        if (r.id === rule.id) return
-        if (r.type === 'wrapper' && r.group === 'event') {
-            eventRules.push(r)
-        } else if (r.group === 'user') {
-            userRules.push(r)
-        }
+    await scrollUserListForEvaluation({
+        list,
+        scroll,
+        handleRule: async ({ rule_id, user_id, result }) => {
+            await ruleChunker.add({ rule_id, user_id, result })
+        },
+        handleEntry: async (user, result) => {
+            if (result) await userChunker.add(user.id)
+        },
     })
 
-    for await (const users of scroll) {
-
-        // For each user, evaluate parts and batch enqueue
-        for (const user of users) {
-
-            const parts: RuleWithEvaluationResult[] = []
-            const events = await getUserEventsForRules([user.id], eventRules)
-
-            for (const rule of eventRules) {
-                const result = check({
-                    user: user.flatten(),
-                    events: events.map(e => e.flatten()),
-                }, rule)
-                await ruleChunker.add({
-                    rule_id: rule.id,
-                    user_id: user.id,
-                    result,
-                })
-                parts.push({
-                    ...rule,
-                    result,
-                })
-            }
-
-            const result = checkRules(user, rule, [...parts, ...userRules])
-            if (result) {
-                await userChunker.add(user.id)
-            }
-        }
-    }
-
-    // Insert any remaining users
+    // Insert any remaining chunks
     await ruleChunker.flush()
     await userChunker.flush()
 
@@ -287,6 +326,54 @@ export const populateList = async (list: List) => {
 
     // Update list status to ready
     await updateListState(id, { state: 'ready' })
+}
+
+export const refreshList = async (list: List, types: DateRuleTypes) => {
+
+    // If there are any rules that compare before a dynamic date
+    // then we cant optimize and need to regenerate the entire list
+    if (types.before) {
+        return await populateList(list)
+    }
+
+    const { id } = list
+    await updateListState(id, { state: 'loading' })
+
+    const scroll = User.scroll(q =>
+        q.leftJoin('user_list', 'user_list.user_id', 'users.id')
+            .where('project_id', list.project_id)
+            .where('user_list.list_id', list.id)
+            .select('users.*'),
+    )
+
+    const userChunker = new Chunker<number>(async userIds => {
+        await UserList.delete(qb => qb.whereIn('user_id', userIds)
+            .where('list_id', list.id))
+    }, 50)
+
+    await scrollUserListForEvaluation({
+        list,
+        scroll,
+        since: types.value,
+        handleRule: async ({ rule_id, user_id, result }) => {
+            if (!result) {
+                await RuleEvaluation.update(
+                    qb => qb
+                        .where('rule_id', rule_id)
+                        .where('user_id', user_id),
+                    { result },
+                )
+            }
+        },
+        handleEntry: async (user, result) => {
+            if (!result) await userChunker.add(user.id)
+        },
+    })
+
+    await userChunker.flush()
+
+    // Update list status to ready
+    await updateListState(id, { state: 'ready', refreshed_at: new Date() })
 }
 
 export const isUserInList = async (user_id: number, list_id: number) => {
@@ -354,6 +441,6 @@ export const listUserCount = async (listId: number, since?: CountRange): Promise
     })
 }
 
-export const updateListState = async (id: number, params: Partial<Pick<List, 'state' | 'version' | 'users_count'>>) => {
+export const updateListState = async (id: number, params: Partial<Pick<List, 'state' | 'version' | 'users_count' | 'refreshed_at'>>) => {
     return await List.updateAndFetch(id, params)
 }

--- a/apps/platform/src/lists/ProcessListsJob.ts
+++ b/apps/platform/src/lists/ProcessListsJob.ts
@@ -1,6 +1,8 @@
+import { differenceInHours } from 'date-fns'
 import { Job } from '../queue'
 import List from './List'
 import ListStatsJob from './ListStatsJob'
+import ListRefreshJob from './ListRefreshJob'
 
 export default class ProcessListsJob extends Job {
     static $name = 'process_lists_job'
@@ -9,7 +11,19 @@ export default class ProcessListsJob extends Job {
 
         const lists = await List.all(qb => qb.whereNot('state', 'loading'))
         for (const list of lists) {
+
+            // Update stats on all lists
             await ListStatsJob.from(list.id, list.project_id).queue()
+
+            // Refresh lists with date rules if 24hrs has elapsed
+            if (list.refreshed_at
+                && differenceInHours(
+                    new Date(),
+                    list.refreshed_at,
+                ) >= 24
+            ) {
+                await ListRefreshJob.from(list.id, list.project_id).queue()
+            }
         }
     }
 }

--- a/apps/platform/src/rules/DateRule.ts
+++ b/apps/platform/src/rules/DateRule.ts
@@ -1,6 +1,14 @@
 import { isAfter, isBefore, isEqual } from 'date-fns'
 import { RuleCheck, RuleEvalException } from './RuleEngine'
 import { compile, queryValue } from './RuleHelpers'
+import Rule, { RuleTree } from './Rule'
+
+export const dateCompile = (rule: Rule | RuleTree) => compile(rule, item => {
+    if (typeof item === 'string' || typeof item === 'number') {
+        return new Date(item)
+    }
+    throw new RuleEvalException(rule, 'invalid value for date comparison')
+})
 
 export default {
     check({ rule, value }) {
@@ -14,12 +22,7 @@ export default {
             return !values.some(d => d)
         }
 
-        const ruleValue = compile(rule, item => {
-            if (typeof item === 'string' || typeof item === 'number') {
-                return new Date(item)
-            }
-            throw new RuleEvalException(rule, 'invalid value for date comparison')
-        })
+        const ruleValue = dateCompile(rule)
 
         return values.some(d => {
             switch (rule.operator) {

--- a/apps/platform/src/rules/RuleError.ts
+++ b/apps/platform/src/rules/RuleError.ts
@@ -1,0 +1,7 @@
+export default {
+    CompileError: (stack: string) => ({
+        message: `A rule contains an invalid Handlebars template (${stack})`,
+        code: 7000,
+        statusCode: 422,
+    }),
+}

--- a/apps/platform/src/rules/RuleHelpers.ts
+++ b/apps/platform/src/rules/RuleHelpers.ts
@@ -3,7 +3,11 @@ import { AnyJson, RuleTree } from './Rule'
 import { compileTemplate } from '../render'
 import { visit } from '../utilities'
 
-export const queryValue = <T>(value: Record<string, unknown>, rule: RuleTree, cast: (item: any) => T): T[] => {
+export const queryValue = <T>(
+    value: Record<string, unknown>,
+    rule: RuleTree,
+    cast: (item: any) => T = v => v,
+): T[] => {
     let path = rule.path
     if (!value || !path) return []
     if (!path.startsWith('$.') && !path.startsWith('$[')) path = '$.' + path

--- a/apps/platform/src/users/UserRepository.ts
+++ b/apps/platform/src/users/UserRepository.ts
@@ -177,7 +177,11 @@ export const disableNotifications = async (userId: number, tokens: string[]): Pr
     return true
 }
 
-export const getUserEventsForRules = async (userIds: number[], rules: RuleTree[]) => {
+export const getUserEventsForRules = async (
+    userIds: number[],
+    rules: RuleTree[],
+    since?: Date | null,
+) => {
     if (!userIds.length || !rules.length) return []
     const names = rules.reduce<string[]>((a, rule) => {
         if (rule) {
@@ -186,9 +190,11 @@ export const getUserEventsForRules = async (userIds: number[], rules: RuleTree[]
         return a
     }, []).filter((o, i, a) => a.indexOf(o) === i)
     if (!names.length) return []
-    return UserEvent.all(qb => qb
-        .whereIn('user_id', userIds)
-        .whereIn('name', names)
-        .orderBy('id', 'asc'),
-    )
+    return UserEvent.all(qb => {
+        qb.whereIn('user_id', userIds)
+            .whereIn('name', names)
+            .orderBy('id', 'asc')
+        if (since) qb.where('created_at', '>=', since)
+        return qb
+    })
 }

--- a/apps/ui/src/views/users/RuleBuilder.css
+++ b/apps/ui/src/views/users/RuleBuilder.css
@@ -75,6 +75,10 @@
     border-left-color: transparent;
 }
 
+.rule .ui-text-input:hover {
+    z-index: 1;
+}
+
 .rule-inner {
     position: relative;
     display: flex;

--- a/docs/docs/how-to/lists.md
+++ b/docs/docs/how-to/lists.md
@@ -4,9 +4,34 @@ sidebar_position: 4
 ---
 
 # Lists
-Lists allow you to group sets of users together to target them for messages. There are two different kinds of lists:
+Lists allow you to group sets of users together to target them for campaigns. There are two different kinds of lists:
 - **Dynamic**: These lists generate themselves based on a set of criteria/rules that are set. After the initial list of users is generated, any users who fall into the criteria moving forward will find themselves added to the list.
 - **Static**: These are lists that are fixed and do not change on their own. The subset of users within them comes from an uploaded CSV document.
+
+## Dynamic Lists
+You can create a dynamic list by building a ruleset to target which users you want to be included. After creating your initial ruleset, the criteria is run across all users to build the initial list (this process can take some time depending on the number of users you have). Once the initial list is built, additions and substractions from the list happen instantly based on inbound events and user property updates.
+
+### Rules
+Rules can target both events and user properties using JSON dot notation and involves matching a property or event to a provided value. Values can be cast to different types allowing for different operations. The primary data types are:
+- Strings
+- Numbers
+- Booleans
+- Dates
+- Arrays
+
+The value field for each part of a ruleset accepts [Handlebars and all associated functions](/how-to/campaigns/templates#helpers).
+
+#### Using Relative Dates
+List membership primarily operates off of inbound events and user property updates. Membership generated in this fashion is instant and really efficient. However, sometimes membership needs to be determined based on relative values. An example of this might be a list that only includes users who have performed an action without a given period of time. To achieve this, you can use [date math and Handlebars functions](/how-to/campaigns/templates#dates).
+
+To use relative dates, pick the `Date` data type for an event ruleset filter and then use the `{{ now }}` value along with date match to generate the date you are looking for. An example of this might be `{{ subDate "now" 30 "days" }}`.
+
+Once you save, Parcelvoy automatically detects dynamic parameters in your ruleset and will recalculate membership once daily. 
+
+:::caution
+Where possible, Parcelvoy attempts to efficiently re-evaluate membership in your list but depending on your logic this may not be possible and a full list re-generation may occur. This primarily happens when using relative dates and a `before` operator since all users not in the list must also be evaluated.
+:::
+
 
 ## Static Lists
 You can create lists that contain fixed data that can be uploaded via CSV. When importing data an `external_id` column is required containing the identifier for your user. Additional there are some reserved fields which enhance other functionality in the process. Anything that is not a reserved or required field will get uploaded as custom data.


### PR DESCRIPTION
First pass at allowing for daily regeneration of lists that include relative date math in them. This solution is relatively efficient for date math that compares forwards (or looks for dates greater than the generated value) but very inefficient for date math comparing backwards. This is because backwards comparison typically opens the criteria for membership in a list to a greater population requiring re-evaluating all users in a given project (not just looking at those already in the list). Depending on user base size this can take a solid amount of time. 

Will continue investigating how to improve situations involving backwards looking relative dates, but most described use cases look forward to limit membership for only a defined criteria before removing users already in the list (vs looking to add more).

Addresses #514 and #535