### PR TITLE
Better handle users with multiple devices and devices with expired tokens

### DIFF
--- a/apps/platform/src/providers/push/LocalPushProvider.ts
+++ b/apps/platform/src/providers/push/LocalPushProvider.ts
@@ -134,7 +134,6 @@ export default class LocalPushProvider extends PushProvider {
     }
 
     async send(push: Push): Promise<PushResponse> {
-        // TODO: Need a better way of bubbling up errors
         const { tokens, title, body, custom } = push
         const response = await this.transport.send(typeof tokens === 'string' ? [tokens] : tokens, {
             title,
@@ -153,13 +152,14 @@ export default class LocalPushProvider extends PushProvider {
             }
         }
 
-        if (response[0].failure > 0) {
+        if (response[0].failure > 0 && response[0].success <= 0) {
             throw new PushError('local', response[0].message[0].errorMsg, invalidTokens)
         } else {
             return {
                 push,
                 success: true,
                 response: response[0].message[0].messageId,
+                invalidTokens,
             }
         }
     }

--- a/apps/platform/src/providers/push/LoggerPushProvider.ts
+++ b/apps/platform/src/providers/push/LoggerPushProvider.ts
@@ -27,6 +27,7 @@ export default class LoggerPushProvider extends PushProvider {
             push,
             success: true,
             response: '',
+            invalidTokens: [],
         }
     }
 

--- a/apps/platform/src/providers/push/Push.ts
+++ b/apps/platform/src/providers/push/Push.ts
@@ -10,4 +10,5 @@ export interface PushResponse {
     push: Push
     success: boolean
     response?: string
+    invalidTokens: string[]
 }

--- a/apps/platform/src/providers/push/PushChannel.ts
+++ b/apps/platform/src/providers/push/PushChannel.ts
@@ -14,7 +14,7 @@ export default class PushChannel {
         }
     }
 
-    async send(template: PushTemplate, variables: Variables): Promise<PushResponse | unknown> {
+    async send(template: PushTemplate, variables: Variables): Promise<PushResponse | undefined> {
 
         // Find tokens from active devices with push enabled
         const tokens = variables.user.pushEnabledDevices.map(device => device.token)

--- a/apps/platform/src/providers/push/PushJob.ts
+++ b/apps/platform/src/providers/push/PushJob.ts
@@ -42,7 +42,15 @@ export default class PushJob extends Job {
 
             // Send the push and update the send record
             const result = await channel.send(template, data)
-            await finalizeSend(data, result)
+            if (result) {
+                await finalizeSend(data, result)
+
+                // A user may have multiple devices some of which
+                // may have failed even though the push was
+                // successful. We need to check for those and
+                // disable them
+                if (result.invalidTokens.length) await disableNotifications(user.id, result.invalidTokens)
+            }
 
         } catch (error: any) {
             if (error instanceof PushError) {


### PR DESCRIPTION
Currently if a user has multiple devices and one of them has an invalid token we fail the entire send (even though some of them were unsuccessful). This updates the behavior to not consider a push notification send as a failure unless 100% of the sends were unsuccessful. 

Fixes #546 