### PR TITLE
Improve logic for stalled sends

### DIFF
--- a/apps/platform/src/campaigns/CampaignEnqueueSendsJob.ts
+++ b/apps/platform/src/campaigns/CampaignEnqueueSendsJob.ts
@@ -1,5 +1,5 @@
 import { Job } from '../queue'
-import { campaignSendReadyQuery, checkStalledSends, getCampaign, sendCampaignJob } from './CampaignService'
+import { campaignSendReadyQuery, failStalledSends, getCampaign, sendCampaignJob } from './CampaignService'
 import { CampaignJobParams } from './Campaign'
 import { chunk } from '../utilities'
 import App from '../app'
@@ -39,7 +39,7 @@ export default class CampaignEnqueueSendsJob extends Job {
         })
 
         // Look for items that have stalled out and mark them as failed
-        await checkStalledSends(campaign.id)
+        await failStalledSends(campaign)
 
         await releaseLock(key)
     }

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -20,7 +20,7 @@ import CampaignError from './CampaignError'
 import CampaignGenerateListJob from './CampaignGenerateListJob'
 import Project from '../projects/Project'
 import Template from '../render/Template'
-import { subDays } from 'date-fns'
+import { differenceInDays, subDays } from 'date-fns'
 import { raw } from '../core/Model'
 
 export const pagedCampaigns = async (params: PageParams, projectId: number) => {
@@ -313,12 +313,30 @@ export const campaignSendReadyQuery = (
     return query
 }
 
-export const checkStalledSends = (campaignId: number) => {
-    return CampaignSend.query()
-        .where('campaign_sends.send_at', '<', subDays(Date.now(), 2))
+export const failStalledSends = async (campaign: Campaign) => {
+
+    const stalledDays = 2
+
+    // Its not possible to have any stalled records if the campaign send
+    // was less than the number of days we are checking for
+    if (
+        campaign.send_at
+        && differenceInDays(
+            Date.now(),
+            new Date(campaign.send_at),
+        ) > stalledDays
+    ) return
+
+    const query = CampaignSend.query()
+        .where('campaign_sends.send_at', '<', subDays(Date.now(), stalledDays))
         .where('campaign_sends.state', 'throttled')
-        .where('campaign_id', campaignId)
-        .update({ state: 'failed' })
+        .where('campaign_id', campaign.id)
+        .select('id')
+    await chunk(query, 25, async (items) => {
+        await CampaignSend.query()
+            .update({ state: 'failed' })
+            .whereIn('id', items)
+    }, ({ id }: Pick<CampaignSend, 'id'>) => id)
 }
 
 export const recipientQuery = (campaign: Campaign) => {

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -324,7 +324,7 @@ export const failStalledSends = async (campaign: Campaign) => {
         && differenceInDays(
             Date.now(),
             new Date(campaign.send_at),
-        ) > stalledDays
+        ) >= stalledDays
     ) return
 
     const query = CampaignSend.query()


### PR DESCRIPTION
- Reduces how often it runs by only running if a campaign has been sending for longer than the check delta. 
- Reduces deadlocks by reading records and then marking by ID instead of doing update in the DB

Related to #541 