### PR TITLE
feature: Allow handlebars usage in PushTemplate

### DIFF
--- a/apps/platform/src/render/Template.ts
+++ b/apps/platform/src/render/Template.ts
@@ -192,15 +192,16 @@ export class PushTemplate extends Template {
             return body
         }, {} as Record<string, any>)
 
+        const renderedUrl = Render(this.url, variables)
         const url = project.link_wrap_push
             ? paramsToEncodedLink({
                 userId: user.id,
                 campaignId: context.campaign_id,
                 referenceId: context.reference_id,
-                redirect: this.url,
+                redirect: renderedUrl,
                 path: 'c',
             })
-            : this.url
+            : renderedUrl
 
         return {
             topic: this.topic,


### PR DESCRIPTION
In our workflows, we want to send custom deeplinks to users based on some of their attributes. For this to work, we need to have handlebars interpretation for URLs.

This PR does just that by calling the `Render` method on the URL before wrapping it.