### PR TITLE
Don't error our device saving for nonexistent user

### DIFF
--- a/apps/platform/src/queue/Job.ts
+++ b/apps/platform/src/queue/Job.ts
@@ -6,9 +6,14 @@ interface JobOptions {
     jobId?: string
 }
 
+interface JobState {
+    attemptsMade: number
+}
+
 export interface EncodedJob {
     data: any
     options: JobOptions
+    state: JobState
     name: string
     token?: string
 }
@@ -27,6 +32,10 @@ export default class Job implements EncodedJob {
     options: JobOptions = {
         delay: 0,
         attempts: 3,
+    }
+
+    state: JobState = {
+        attemptsMade: 0,
     }
 
     static $name: string = Job.constructor.name

--- a/apps/platform/src/queue/RedisQueueProvider.ts
+++ b/apps/platform/src/queue/RedisQueueProvider.ts
@@ -95,6 +95,9 @@ export default class RedisQueueProvider implements QueueProvider {
                     ...job.data.options,
                     jobId: job.id,
                 },
+                state: {
+                    attemptsMade: job.attemptsMade,
+                },
                 token,
             })
         }, {

--- a/apps/platform/src/users/UserDeviceJob.ts
+++ b/apps/platform/src/users/UserDeviceJob.ts
@@ -13,7 +13,14 @@ export default class UserDeviceJob extends Job {
         return new this(data)
     }
 
-    static async handler({ project_id, ...device }: UserDeviceTrigger) {
-        await saveDevice(project_id, device)
+    static async handler({ project_id, ...device }: UserDeviceTrigger, job: UserDeviceJob) {
+        const attempts = job.options.attempts ?? 1
+        const attemptsMade = job.state.attemptsMade ?? 0
+
+        try {
+            await saveDevice(project_id, device)
+        } catch (error) {
+            if (attemptsMade < (attempts - 1)) throw error
+        }
     }
 }


### PR DESCRIPTION
Currently if there are timing issues or a user is deleted but a device request comes in subsequently it will error out when in reality it should just stop retrying since there isn't an action that can be taken.