### PR TITLE
Exploration to reduce deadlocks

### DIFF
--- a/apps/platform/db/migrations/20241228214210_modify_journey_user_step_indexes.js
+++ b/apps/platform/db/migrations/20241228214210_modify_journey_user_step_indexes.js
@@ -1,0 +1,13 @@
+exports.up = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.index(['journey_id', 'type', 'delay_until'])
+        table.dropIndex(['type', 'delay_until'])
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('journey_user_step', function(table) {
+        table.index(['type', 'delay_until'])
+        table.dropIndex(['journey_id', 'type', 'delay_until'])
+    })
+}

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -295,7 +295,7 @@ export const generateSendList = async (campaign: SentCampaign) => {
         await CampaignSend.query()
             .insert(items)
             .onConflict(['campaign_id', 'user_id', 'reference_id'])
-            .merge(['state', 'send_at'])
+            .ignore()
     }, ({ user_id, timezone }: { user_id: number, timezone: string }) =>
         CampaignSend.create(campaign, project, User.fromJson({ id: user_id, timezone })),
     )

--- a/apps/platform/src/campaigns/CampaignService.ts
+++ b/apps/platform/src/campaigns/CampaignService.ts
@@ -295,7 +295,7 @@ export const generateSendList = async (campaign: SentCampaign) => {
         await CampaignSend.query()
             .insert(items)
             .onConflict(['campaign_id', 'user_id', 'reference_id'])
-            .ignore()
+            .merge(['state', 'send_at'])
     }, ({ user_id, timezone }: { user_id: number, timezone: string }) =>
         CampaignSend.create(campaign, project, User.fromJson({ id: user_id, timezone })),
     )

--- a/apps/platform/src/lists/ListEvaluateUserJob.ts
+++ b/apps/platform/src/lists/ListEvaluateUserJob.ts
@@ -1,7 +1,6 @@
 import App from '../app'
 import { cacheIncr } from '../config/redis'
 import { Job } from '../queue'
-import { JobPriority } from '../queue/Job'
 import { getUser } from '../users/UserRepository'
 import { DynamicList } from './List'
 import { CacheKeys, cleanupList, evaluateUserList, getList } from './ListService'
@@ -16,12 +15,6 @@ interface ListEvaluateUserParams {
 
 export default class ListEvaluateUserJob extends Job {
     static $name = 'list_evaluate_user_job'
-
-    options = {
-        delay: 0,
-        attempts: 3,
-        priority: JobPriority.low,
-    }
 
     static from(params: ListEvaluateUserParams): ListEvaluateUserJob {
         return new this(params)


### PR DESCRIPTION
Simple change to potentially reduce gap locks by not having to re-select records for update