### PR TITLE
Force timezone check during record creation

### DIFF
--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -4,7 +4,7 @@ import Model, { ModelParams } from '../core/Model'
 import List from '../lists/List'
 import Template from '../render/Template'
 import Subscription from '../subscriptions/Subscription'
-import { crossTimezoneCopy } from '../utilities'
+import { crossTimezoneCopy, isValidIANATimezone } from '../utilities'
 import Project from '../projects/Project'
 import { User } from '../users/User'
 
@@ -77,6 +77,9 @@ export class CampaignSend extends Model {
         project: Pick<Project, 'timezone'>,
         user: Pick<User, 'id' | 'timezone'>,
     ): CampaignSendParams {
+        const timezone = isValidIANATimezone(user.timezone)
+            ? user.timezone
+            : project.timezone
         return {
             user_id: user.id,
             campaign_id: campaign.id,
@@ -85,7 +88,7 @@ export class CampaignSend extends Model {
                 ? crossTimezoneCopy(
                     campaign.send_at,
                     project.timezone,
-                    user.timezone ?? project.timezone,
+                    timezone,
                 )
                 : campaign.send_at,
         }

--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -88,7 +88,7 @@ export class CampaignSend extends Model {
                 ? crossTimezoneCopy(
                     campaign.send_at,
                     project.timezone,
-                    timezone,
+                    timezone ?? project.timezone,
                 )
                 : campaign.send_at,
         }

--- a/apps/platform/src/utilities/index.ts
+++ b/apps/platform/src/utilities/index.ts
@@ -138,6 +138,19 @@ export const partialMatchLocale = (locale1?: string, locale2?: string) => {
     return locale1 === locale2 || locale1Root === locale2Root
 }
 
+export const isValidIANATimezone = (timezone?: string) => {
+    try {
+        if (!timezone || typeof timezone !== 'string') {
+            return false
+        }
+
+        Intl.DateTimeFormat(undefined, { timeZone: timezone })
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
 export const crossTimezoneCopy = (
     date: Date,
     fromTimezone: string,

--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -61,9 +61,9 @@ Create or update a user profile with associated traits.
 - **anonymous_id** string (optional)
 - **external_id** string
 - **email** string (optional)
-- **phone** string (optional)
-- **timezone** string (optional)
-- **locale** string (optional)
+- **phone** string (optional) - Phone number in E.164 format
+- **timezone** string (optional) - The users timezone provided in IANA format (i.e. America/Chicago)
+- **locale** string (optional) - The locale of the user use for language and formatting (i.e `es` or `en`)
 - **data** object (optional)
 
 #### Responses

--- a/docs/docs/how-to/lists.md
+++ b/docs/docs/how-to/lists.md
@@ -43,7 +43,7 @@ You can create lists that contain fixed data that can be uploaded via CSV. When 
 - `first_name`: The first name of the user
 - `last_name`: The last name of the user
 - `email`: The users email
-- `phone`: The users phone number with country code
-- `timezone`: The users timezone provided in IANA format (America/Chicago)
-- `locale`: The language
+- `phone`: The users phone number in E.164 format
+- `timezone`: The users timezone provided in IANA format (i.e. America/Chicago)
+- `locale`: The locale of the user use for language and formatting (i.e `es` or `en`)
 - `created_at`: When a user was created to override internal time setting. Must be in ISO 8601 format


### PR DESCRIPTION
This is most likely a temporary code change only as I am unsure as to the performance implications of it all. But at the very least it also highlights even more the required formats in the documentation