### PR TITLE
Make event ingestion idempotent

### DIFF
--- a/apps/platform/db/migrations/20250119154321_add_events_distinct_id.js
+++ b/apps/platform/db/migrations/20250119154321_add_events_distinct_id.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+    await knex.schema.alterTable('user_events', function(table) {
+        table.string('distinct_id')
+    })
+
+    // Splitting into second operation to allow for instant add
+    // and less table locking
+    await knex.schema.alterTable('user_events', function(table) {
+        table.unique('distinct_id')
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('user_events', function(table) {
+        table.dropColumn('distinct_id')
+    })
+}

--- a/apps/platform/src/client/Client.ts
+++ b/apps/platform/src/client/Client.ts
@@ -27,6 +27,7 @@ export type ClientDeleteUsersRequest = string[]
 
 export type ClientPostEvent = {
     name: string
+    distinct_id?: string
     data?: Record<string, unknown>
     user?: ClientIdentifyParams
     created_at?: Date
@@ -53,6 +54,7 @@ export interface SegmentContext {
 // https://segment.com/docs/connections/spec/common/
 export type SegmentPostEvent = {
     event: string
+    messageId: string
     anonymousId: string
     userId: string
     previousId?: string

--- a/apps/platform/src/client/ClientController.ts
+++ b/apps/platform/src/client/ClientController.ts
@@ -185,6 +185,10 @@ const postEventsRequest: JSONSchemaType<ClientPostEventsRequest> = {
                 type: 'string',
                 nullable: true,
             },
+            distinct_id: {
+                type: 'string',
+                nullable: true,
+            },
             data: {
                 type: 'object',
                 nullable: true,

--- a/apps/platform/src/client/SegmentController.ts
+++ b/apps/platform/src/client/SegmentController.ts
@@ -103,6 +103,7 @@ router.post('/segment', async ctx => {
                 event: {
                     ...identity,
                     name: event.event,
+                    distinct_id: event.messageId,
                     data: { ...event.properties, ...event.context },
                     created_at: new Date(event.timestamp),
                 },

--- a/apps/platform/src/core/Model.ts
+++ b/apps/platform/src/core/Model.ts
@@ -245,15 +245,16 @@ export default class Model {
         }
     }
 
-    static async insert<T extends typeof Model>(this: T, data: Partial<InstanceType<T>>, db?: Database): Promise<number>
-    static async insert<T extends typeof Model>(this: T, data: Partial<InstanceType<T>>[], db?: Database): Promise<number[]>
+    static async insert<T extends typeof Model>(this: T, data: Partial<InstanceType<T>>, db?: Database, query?: Query): Promise<number>
+    static async insert<T extends typeof Model>(this: T, data: Partial<InstanceType<T>>[], db?: Database, query?: Query): Promise<number[]>
     static async insert<T extends typeof Model>(
         this: T,
         data: Partial<InstanceType<T>> | Partial<InstanceType<T>>[] = {},
         db: Database = App.main.db,
+        query: Query = qb => qb,
     ): Promise<number | number[]> {
         const formattedData = Array.isArray(data) ? data.map(o => this.formatJson(o)) : this.formatJson(data)
-        const value = await this.table(db).insert(formattedData)
+        const value = await query(this.table(db)).insert(formattedData)
         if (Array.isArray(data)) return value
         return value[0]
     }

--- a/apps/platform/src/journey/JourneyService.ts
+++ b/apps/platform/src/journey/JourneyService.ts
@@ -130,6 +130,9 @@ export const triggerEntrance = async (journey: Journey, payload: JourneyEntrance
         },
     }).handle<{ user: User, event: UserEvent }>()
 
+    // If no event because of idempotency, return
+    if (!event) return
+
     // create new entrance
     const entrance_id = await JourneyUserStep.insert({
         journey_id: journey.id,

--- a/apps/platform/src/providers/email/SMPTEmailProvider.ts
+++ b/apps/platform/src/providers/email/SMPTEmailProvider.ts
@@ -51,6 +51,7 @@ export default class SMTPEmailProvider extends EmailProvider {
             port: this.port,
             secure: this.secure,
             auth: this.auth,
+            pool: true,
         })
     }
 

--- a/apps/platform/src/users/UserEvent.ts
+++ b/apps/platform/src/users/UserEvent.ts
@@ -7,6 +7,7 @@ export interface TemplateEvent extends Record<string, any> {
 export class UserEvent extends Model {
     project_id!: number
     user_id!: number
+    distinct_id?: string
     name!: string
     data!: Record<string, unknown>
 
@@ -21,4 +22,4 @@ export class UserEvent extends Model {
     }
 }
 
-export type UserEventParams = Pick<UserEvent, 'name' | 'data'>
+export type UserEventParams = Pick<UserEvent, 'name' | 'distinct_id' | 'data'>

--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -147,6 +147,7 @@ An array containing at least one object with the following parameters:
 - **name** string (optional) - The name of the event
 - **anonymous_id** string
 - **external_id** string
+- **distinct_id** string (optional) - An unique identifier for the event to ensure idempotency
 - **data** object (optional)
 
 Either an anonymous or external ID is required in order to post an event.


### PR DESCRIPTION
Allows for passing in a `distinct_id` parameter to events (or utilize the existing `messageId` from Segment) to make event ingestion idempotent and prevent duplicates and duplicate logic running.