### PR TITLE
Campaign list generation performance improvements

### DIFF
--- a/apps/platform/db/migrations/20250307055453_update_campaign_send_primary_keys.js
+++ b/apps/platform/db/migrations/20250307055453_update_campaign_send_primary_keys.js
@@ -1,0 +1,32 @@
+exports.up = async function(knex) {
+    await knex.schema.alterTable('campaign_sends', table => {
+        table.integer('id').alter()
+    })
+
+    await knex.raw('alter table campaign_sends drop primary key')
+
+    await knex.schema.alterTable('campaign_sends', table => {
+        table.dropColumn('id')
+    })
+
+    await knex.raw('alter table campaign_sends add primary key (campaign_id, user_id, reference_id)')
+
+    await knex.schema.alterTable('campaign_sends', table => {
+        table.index('user_id', 'campaign_sends_user_id_foreign')
+        table.dropUnique(['user_id', 'campaign_id', 'reference_id'])
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.alterTable('campaign_sends', table => {
+        table.unique(['user_id', 'campaign_id', 'reference_id'])
+    })
+
+    await knex.raw('alter table campaign_sends drop primary key')
+
+    await knex.schema.alterTable('campaign_sends', table => {
+        table.increments('id')
+    })
+
+    await knex.raw('alter table campaign_sends add primary key (id)')
+}

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -65,7 +65,7 @@
     "docker:build": "docker buildx build -f ./Dockerfile -t ghcr.io/parcelvoy/api:latest -t ghcr.io/parcelvoy/api:$npm_config_tag ../../",
     "docker:build:push": "npm run docker:build -- --push",
     "migration:create": "node ./scripts/create-migration.mjs",
-    "package:publish": "npm run build && npm version $npm_config_tag --no-git-tag-version && npm pack && npm publish --tag=latest --access public"
+    "package:publish": "npm run build && npm version $npm_config_tag --no-git-tag-version && npm pack && npm publish --access public"
   },
   "devDependencies": {
     "@types/busboy": "^1.5.0",

--- a/apps/platform/src/campaigns/Campaign.ts
+++ b/apps/platform/src/campaigns/Campaign.ts
@@ -1,6 +1,6 @@
 import Provider from '../providers/Provider'
 import { ChannelType } from '../config/channels'
-import Model, { ModelParams } from '../core/Model'
+import Model, { BaseModel, ModelParams } from '../core/Model'
 import List from '../lists/List'
 import Template from '../render/Template'
 import Subscription from '../subscriptions/Subscription'
@@ -58,7 +58,7 @@ export type CampaignUpdateParams = Omit<CampaignParams, 'channel' | 'type'>
 
 export type CampaignSendState = 'pending' | 'sent' | 'throttled' | 'failed' | 'bounced' | 'aborted'
 export type CampaignSendReferenceType = 'journey' | 'trigger'
-export class CampaignSend extends Model {
+export class CampaignSend extends BaseModel {
     campaign_id!: number
     user_id!: number
     state!: CampaignSendState

--- a/apps/platform/src/campaigns/CampaignEnqueueSendsJob.ts
+++ b/apps/platform/src/campaigns/CampaignEnqueueSendsJob.ts
@@ -33,8 +33,8 @@ export default class CampaignEnqueueSendsJob extends Job {
 
         // Anything that is ready to be sent, enqueue for sending
         const query = campaignSendReadyQuery(campaign.id, includeThrottled, ratePerMinute)
-        await chunk<{ user_id: number, send_id: number }>(query, 100, async (items) => {
-            const jobs = items.map(({ user_id, send_id }) => sendCampaignJob({ campaign, user: user_id, send_id }))
+        await chunk<{ user_id: number, reference_id?: string }>(query, 100, async (items) => {
+            const jobs = items.map(({ user_id, reference_id }) => sendCampaignJob({ campaign, user: user_id, reference_id }))
             await App.main.queue.enqueueBatch(jobs)
         })
 

--- a/apps/platform/src/campaigns/CampaignInteractJob.ts
+++ b/apps/platform/src/campaigns/CampaignInteractJob.ts
@@ -25,7 +25,7 @@ export default class CampaignInteractJob extends Job {
         if (!send) return
 
         if (type === 'opened' && !send.opened_at) {
-            await updateCampaignSend(send.id, { opened_at: new Date() })
+            await updateCampaignSend(campaign_id, user_id, reference_id, { opened_at: new Date() })
             await App.main.redis.sadd(CacheKeys.pendingStats, campaign_id)
         }
 
@@ -34,11 +34,11 @@ export default class CampaignInteractJob extends Job {
             if (!send.opened_at) {
                 updates.opened_at = new Date()
             }
-            await updateCampaignSend(send.id, updates)
+            await updateCampaignSend(campaign_id, user_id, reference_id, updates)
         }
 
         if (type === 'complained' || type === 'bounced') {
-            await updateCampaignSend(send.id, { state: 'bounced' })
+            await updateCampaignSend(campaign_id, user_id, reference_id, { state: 'bounced' })
         }
 
         if (subscription_id && action === 'unsubscribe') {

--- a/apps/platform/src/campaigns/CampaignStateJob.ts
+++ b/apps/platform/src/campaigns/CampaignStateJob.ts
@@ -9,21 +9,23 @@ export default class CampaignStateJob extends Job {
 
     static async handler() {
 
-        // Fetch anything that is currently running or has finished
-        // within the last two days or has activity
-        const openedCampaignIds = await App.main.redis.smembers(CacheKeys.pendingStats)
+        // Fetch anything that is currently running, has finished
+        // within the last two days or has activity since last run
+        const openedCampaignIds = await App.main.redis.smembers(CacheKeys.pendingStats).then(ids => ids.map(parseInt))
         const campaigns = await Campaign.query()
             .whereIn('state', ['scheduled', 'running'])
             .orWhere(function(qb) {
                 qb.where('state', 'finished')
                     .where('send_at', '>', subDays(Date.now(), 2))
             })
-            .orWhereIn('id', openedCampaignIds.map(id => parseInt(id, 10))) as Campaign[]
+            .orWhereIn('id', openedCampaignIds) as Campaign[]
 
         for (const campaign of campaigns) {
             await updateCampaignProgress(campaign)
         }
 
-        await App.main.redis.srem(CacheKeys.pendingStats, ...campaigns.map(c => c.id))
+        if (campaigns.length) {
+            await App.main.redis.srem(CacheKeys.pendingStats, ...campaigns.map(c => c.id))
+        }
     }
 }

--- a/apps/platform/src/core/searchParams.ts
+++ b/apps/platform/src/core/searchParams.ts
@@ -1,5 +1,5 @@
 import { JSONSchemaType } from 'ajv'
-import Model from './Model'
+import { BaseModel } from './Model'
 
 export interface PageParams {
     limit: number
@@ -13,7 +13,7 @@ export interface PageParams {
     id?: number[]
 }
 
-export interface PageQueryParams<T extends typeof Model> extends PageParams {
+export interface PageQueryParams<T extends typeof BaseModel> extends PageParams {
     fields?: Array<keyof InstanceType<T> | string>
     mode?: 'exact' | 'partial'
 }

--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -307,12 +307,12 @@ export class JourneyAction extends JourneyStep {
 
         // defer job construction so that we have the journey_user_step.id value
         state.job(async () => {
-            const send_id = await getCampaignSend(campaign.id, state.user.id, `${userStep.id}`).then(s => s?.id)
+            const campaignSend = await getCampaignSend(campaign.id, state.user.id, `${userStep.id}`)
 
             const send = triggerCampaignSend({
                 campaign,
                 user: state.user,
-                send_id,
+                exists: !!campaignSend,
                 reference_id: `${userStep.id}`,
                 reference_type: 'journey',
             })

--- a/apps/platform/src/providers/MessageTrigger.ts
+++ b/apps/platform/src/providers/MessageTrigger.ts
@@ -1,5 +1,4 @@
 export interface MessageTrigger {
-    send_id?: number
     campaign_id: number
     user_id: number
     event_id?: number

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -1,7 +1,7 @@
 import { JourneyUserStep } from '../journey/JourneyStep'
 import App from '../app'
-import Campaign, { CampaignSend } from '../campaigns/Campaign'
-import { updateSendState } from '../campaigns/CampaignService'
+import Campaign from '../campaigns/Campaign'
+import { getCampaignSend, updateSendState } from '../campaigns/CampaignService'
 import { Channel } from '../config/channels'
 import { RateLimitResponse } from '../config/rateLimit'
 import { acquireLock } from '../core/Lock'
@@ -30,12 +30,12 @@ interface MessageTriggerHydrated<T> {
     context: RenderContext
 }
 
-export async function loadSendJob<T extends TemplateType>({ campaign_id, user_id, event_id, send_id, reference_type, reference_id }: MessageTrigger): Promise<MessageTriggerHydrated<T> | undefined> {
+export async function loadSendJob<T extends TemplateType>({ campaign_id, user_id, event_id, reference_type, reference_id }: MessageTrigger): Promise<MessageTriggerHydrated<T> | undefined> {
 
     const user = await User.find(user_id)
     const event = await UserEvent.find(event_id)
     const project = await Project.find(user?.project_id)
-    const send = await CampaignSend.find(send_id)
+    const send = await getCampaignSend(campaign_id, user_id, reference_id)
 
     // If user or project is deleted, abort and discard job
     if (!user || !project) return

--- a/apps/platform/src/providers/email/LoggerEmailProvider.ts
+++ b/apps/platform/src/providers/email/LoggerEmailProvider.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../config/logger'
-import { randomInt, sleep } from '../../utilities'
+import { randomInt, sleep, uuid } from '../../utilities'
 import { ExternalProviderParams, ProviderControllers, ProviderSchema } from '../Provider'
 import { createController } from '../ProviderService'
 import { Email } from './Email'
@@ -24,6 +24,17 @@ export default class LoggerEmailProvider extends EmailProvider {
         if (this.addLatency) await sleep(randomInt())
 
         logger.info(message, 'provider:email:logger')
+
+        return {
+            messageId: uuid(),
+            messageSize: 0,
+            messageTime: Date.now(),
+            envelope: {},
+            accepted: [message.to],
+            rejected: [],
+            pending: [],
+            response: 'Message sent to logger',
+        }
     }
 
     async verify(): Promise<boolean> {


### PR DESCRIPTION
- Switches to composite primary key vs auto-incrementing to reduce range locking
- Increased number of campaigns inserted by 10x (produces an inline speed increase in campaign initialization)
- Removed `on duplicate merge` insert logic to prevent deadlocks while inserting records