### PR TITLE
Adds additional context to send errors tracked in Sentry/Bugsnag

### DIFF
--- a/apps/platform/src/error/SentryProvider.ts
+++ b/apps/platform/src/error/SentryProvider.ts
@@ -25,7 +25,9 @@ export default class SentryProvider implements ErrorHandlingProvider {
         })
     }
 
-    notify(error: Error) {
-        Sentry.captureException(error)
+    notify(error: Error, context?: Record<string, any>) {
+        Sentry.captureException(error, {
+            extra: context,
+        })
     }
 }

--- a/apps/platform/src/providers/MessageTriggerService.ts
+++ b/apps/platform/src/providers/MessageTriggerService.ts
@@ -193,7 +193,7 @@ export const failSend = async ({ campaign, user, context }: MessageTriggerHydrat
     }
 
     // Notify of the error if it's a critical one
-    if (error && shouldNotify(error)) App.main.error.notify(error)
+    if (error && shouldNotify(error)) App.main.error.notify(error, context)
 }
 
 export const finalizeSend = async (data: MessageTriggerHydrated<TemplateType>, result: any) => {


### PR DESCRIPTION
Adds contextual data to send failures that bubble up to error tracker. Also makes sure Sentry gets `extra` data

Resolves #666 