### PR TITLE
chore: reduce journey memory usage

### DIFF
--- a/apps/platform/src/journey/JourneyState.ts
+++ b/apps/platform/src/journey/JourneyState.ts
@@ -8,7 +8,7 @@ import { UserEvent } from '../users/UserEvent'
 import { getUserEventsForRules } from '../users/UserRepository'
 import { shallowEqual } from '../utilities'
 import { getEntranceSubsequentSteps, getJourneyStepChildren, getJourneySteps } from './JourneyRepository'
-import { JourneyGate, JourneyStep, JourneyStepChild, journeyStepTypes } from './JourneyStep'
+import { JourneyStep, JourneyStepChild, journeyStepTypes } from './JourneyStep'
 import JourneyUserStep from './JourneyUserStep'
 
 type JobOrJobFunc = Job | ((state: JourneyState) => Promise<Job | undefined>)
@@ -195,20 +195,9 @@ export class JourneyState {
         this._jobs.push(job)
     }
 
-    public async events() {
+    public async events(rule: Rule) {
         // TODO: Find a way to not have to pull in all events, better discern
-        if (!this._events) {
-            this._events = await getUserEventsForRules(
-                this.user.id,
-                this.steps.reduce<Rule[]>((a, c) => {
-                    if (c instanceof JourneyGate) {
-                        a.push(c.rule)
-                    }
-                    return a
-                }, []),
-            )
-        }
-        return this._events
+        return await getUserEventsForRules(this.user.id, rule)
     }
 
     public async timezone() {

--- a/apps/platform/src/journey/JourneyStep.ts
+++ b/apps/platform/src/journey/JourneyStep.ts
@@ -335,7 +335,7 @@ export class JourneyGate extends JourneyStep {
 
         if (!passed && !failed) return
 
-        const events = await state.events()
+        const events = await state.events(this.rule)
 
         const params = {
             user: state.user.flatten(),

--- a/apps/platform/src/users/__tests__/UserRepository.spec.ts
+++ b/apps/platform/src/users/__tests__/UserRepository.spec.ts
@@ -122,30 +122,28 @@ describe('UserRepository', () => {
                 data: { key: 'value3' },
             })
 
-            const rules = [
-                make({
-                    group: 'event',
-                    path: 'name',
-                    value: 'event1',
-                    type: 'wrapper',
-                    operator: 'or',
-                    children: [
-                        make({ type: 'number', path: 'score.total', operator: '<', value: 5 }),
-                        make({ type: 'boolean', path: 'score.isRecord', value: true }),
-                    ],
-                    frequency: {
-                        period: {
-                            unit: 'day',
-                            value: 7,
-                            type: 'rolling',
-                        },
-                        count: 2,
-                        operator: '>=',
+            const rule = make({
+                group: 'event',
+                path: 'name',
+                value: 'event1',
+                type: 'wrapper',
+                operator: 'or',
+                children: [
+                    make({ type: 'number', path: 'score.total', operator: '<', value: 5 }),
+                    make({ type: 'boolean', path: 'score.isRecord', value: true }),
+                ],
+                frequency: {
+                    period: {
+                        unit: 'day',
+                        value: 7,
+                        type: 'rolling',
                     },
-                }),
-            ]
+                    count: 2,
+                    operator: '>=',
+                },
+            })
 
-            const events = await getUserEventsForRules(user.id, rules)
+            const events = await getUserEventsForRules(user.id, rule)
             expect(events).toHaveLength(2)
             expect(events[0].name).toEqual('event1')
         })
@@ -171,30 +169,28 @@ describe('UserRepository', () => {
                 data: { key: 'value2' },
             })
 
-            const rules = [
-                make({
-                    group: 'event',
-                    path: 'name',
-                    value: 'event1',
-                    type: 'wrapper',
-                    operator: 'or',
-                    children: [
-                        make({ type: 'number', path: 'score.total', operator: '<', value: 5 }),
-                        make({ type: 'boolean', path: 'score.isRecord', value: true }),
-                    ],
-                    frequency: {
-                        period: {
-                            unit: 'day',
-                            value: 7,
-                            type: 'rolling',
-                        },
-                        count: 2,
-                        operator: '>=',
+            const rule = make({
+                group: 'event',
+                path: 'name',
+                value: 'event1',
+                type: 'wrapper',
+                operator: 'or',
+                children: [
+                    make({ type: 'number', path: 'score.total', operator: '<', value: 5 }),
+                    make({ type: 'boolean', path: 'score.isRecord', value: true }),
+                ],
+                frequency: {
+                    period: {
+                        unit: 'day',
+                        value: 7,
+                        type: 'rolling',
                     },
-                }),
-            ]
+                    count: 2,
+                    operator: '>=',
+                },
+            })
 
-            const events = await getUserEventsForRules(user.id, rules)
+            const events = await getUserEventsForRules(user.id, rule)
             expect(events).toHaveLength(1)
             expect(events[0].name).toEqual('event1')
         })


### PR DESCRIPTION
Aims to reduce memory usage for large journeys by only fetching the events needed to fulfill the rules of a single gate instead of preemptively fetching all events for all gates in a journey.