### PR TITLE
Fix: Prevent API key modal from opening when clicking copy button

### DIFF
--- a/apps/ui/src/views/settings/ApiKeys.tsx
+++ b/apps/ui/src/views/settings/ApiKeys.tsx
@@ -30,12 +30,6 @@ export default function ProjectApiKeys() {
         }
     }
 
-    const handleCopy = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, value: string) => {
-        await navigator.clipboard.writeText(value)
-        event.stopPropagation()
-        toast.success('Copied API Key')
-    }
-
     return (
         <>
             <SearchTable
@@ -58,9 +52,19 @@ export default function ProjectApiKeys() {
                         key: 'value',
                         title: t('value'),
                         cell: ({ item }) => (
-                            <div className="cell-content">
+                            <div className="cell-content" onClick={(e) => e.stopPropagation()}>
                                 {item.value}
-                                <Button icon={<CopyIcon />} size="small" variant="plain" onClickCapture={async (e) => await handleCopy(e, item.value)} />
+                                <Button
+                                    icon={<CopyIcon />}
+                                    size="small"
+                                    variant="plain"
+                                    type="button"
+                                    onClick={() => {
+                                        void navigator.clipboard.writeText(item.value).then(() => {
+                                            toast.success('Copied API Key')
+                                        })
+                                    }}
+                                />
                             </div>
                         ),
                     },


### PR DESCRIPTION
### Problem
When users click the copy button to copy an API key in the API Keys settings page, the row's click event also fires, causing the edit/update modal to open unexpectedly. This creates a poor user experience where users have to close the modal every time they just want to copy a key.

### Solution
This PR fixes the issue by:
1. Adding `onClick={(e) => e.stopPropagation()}` to the cell-content div containing the API key value and copy button
2. Removing the unnecessary `handleCopy` function that was attempting to stop propagation
3. Simplifying the copy button to use a standard `onClick` handler instead of `onClickCapture`
4. Adding `type="button"` attribute for better semantic HTML

### Changes
- Modified `apps/ui/src/views/settings/ApiKeys.tsx`
  - Removed `handleCopy` function (lines 33-37)
  - Added `stopPropagation` to cell-content div
  - Simplified copy button implementation

### Before & After
**Before**: Clicking copy button → API key copied + modal opens
**After**: Clicking copy button → API key copied only (modal stays closed)