### PR TITLE
Fix entrance detail user display name

### DIFF
--- a/apps/ui/src/views/journey/EntranceDetails.tsx
+++ b/apps/ui/src/views/journey/EntranceDetails.tsx
@@ -27,10 +27,11 @@ export default function EntranceDetails() {
 
     const entrance = userSteps[0]
     const error = userSteps.find(s => s.type === 'error')
+    const displayName = user.full_name ?? user.email ?? user.phone ?? user.id
 
     return (
         <PageContent
-            title={`${user.full_name} - ${journey.name}`}
+            title={`${displayName} - ${journey.name}`}
             desc={
                 <>
                     <Tag variant={error ? 'error' : entrance.ended_at ? 'success' : 'info'}>


### PR DESCRIPTION
This PR fixes the name shown within the entrance details page. The entrance details page right now shows `null` as the user name when the user's `full_name` is not set.

<img width="1255" height="309" alt="Screenshot 2025-10-06 at 15 18 40" src="https://github.com/user-attachments/assets/eed6fc2f-ea72-427b-b30f-0dcc55e6affa" />

---

<img width="1256" height="339" alt="image" src="https://github.com/user-attachments/assets/67370986-3c8d-4be7-8ec2-77cfeda3aaa1" />
