### PR TITLE
Updated campaigns default filter and improved messaging no results

### DIFF
--- a/apps/ui/public/locales/en.json
+++ b/apps/ui/public/locales/en.json
@@ -45,6 +45,7 @@
     "campaign_list_generating": "This list is still generating or has not been published. Sending before it has completed could result in this campaign not sending to all users who will enter the list. Are you sure you want to continue?",
     "campaign_name": "Campaign Name",
     "campaign_variant_add": "Create Experiment",
+    "no_campaigns_found": "No Results, please try adjusting your search or filter criteria.",
     "campaigns": "Campaigns",
     "campaign": "Campaign",
     "cancel": "Cancel",

--- a/apps/ui/src/views/campaign/Campaigns.tsx
+++ b/apps/ui/src/views/campaign/Campaigns.tsx
@@ -123,6 +123,7 @@ export default function Campaigns() {
             )}>
                 <SearchTable
                     {...state}
+                    emptyMessage={t('no_campaigns_found')}
                     columns={[
                         {
                             key: 'name',


### PR DESCRIPTION
This PR updates the default campaigns filter to trigger (Journey) and improves the messaging shown when no results are found.

Trigger campaigns are usually created when setting up a Journey Flow, so it felt confusing that no campaigns appeared by default when opening the campaigns view (#715). By setting the default filter to `trigger` instead of `blast`, users will immediately see their Journey related campaigns, making the experience more intuitive and less confusing.